### PR TITLE
.rlib is a compiled library, not a source file

### DIFF
--- a/src/Microsoft.DevSkim/Microsoft.DevSkim/Resources/languages.json
+++ b/src/Microsoft.DevSkim/Microsoft.DevSkim/Resources/languages.json
@@ -77,7 +77,7 @@
     },
     {
         "name": "rust",
-        "extensions": [ ".rs", ".rlib" ]
+        "extensions": [ ".rs" ]
     },
     {
         "name": "jade",


### PR DESCRIPTION
Remove `.rlib` from rust source file extensions.