### PR TITLE
Fix a typo in the comments definition entry for 'swift'

### DIFF
--- a/src/Microsoft.DevSkim/Microsoft.DevSkim/Resources/comments.json
+++ b/src/Microsoft.DevSkim/Microsoft.DevSkim/Resources/comments.json
@@ -11,7 +11,7 @@
         "jade",
         "objective-C",
         "rust",
-        "wwift",
+        "swift",
         "javascript",
         "java",
         "typescript",


### PR DESCRIPTION
This pull request corrects the comments definition entry for Swift, which was misspelled. 

Resolves #50.