### PR TITLE
Add StringComparison.Ordinal to IndexOf calls, fixes #60.

### DIFF
--- a/src/Microsoft.DevSkim/Microsoft.DevSkim/TextContainer.cs
+++ b/src/Microsoft.DevSkim/Microsoft.DevSkim/TextContainer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -28,7 +29,7 @@ namespace Microsoft.DevSkim
             {
                 if (++pos < _content.Length)
                 {
-                    pos = _content.IndexOf('\n', pos);
+                    pos = _content.IndexOf("\n", pos, StringComparison.Ordinal);
                     _lineEnds.Add(pos);
                 }
             }
@@ -185,11 +186,11 @@ namespace Microsoft.DevSkim
         {
             bool result = false;
             string preText = string.Concat(text.Substring(0, index));
-            int lastPreffix = preText.LastIndexOf(prefix);
+            int lastPreffix = preText.LastIndexOf(prefix, StringComparison.Ordinal);
             if (lastPreffix >= 0)
             {
                 preText = preText.Substring(lastPreffix);
-                int lastSuffix = preText.IndexOf(suffix);
+                int lastSuffix = preText.IndexOf(suffix, StringComparison.Ordinal);
                 if (lastSuffix < 0)
                     result = true;
             }


### PR DESCRIPTION
Based on https://github.com/dotnet/corefx/issues/31103, StringComparison.Ordinal should be used to make indexOf and lastIndexOf behave the same way on Linux and Windows.

Based on the failing example mentioned in #60, this PR should fix it.

```
$ dotnet run analyze ~/tmp/container-security-testing/src/Controllers/OpenPositionsController.cs
file:/tmp/container-security-testing/src/Controllers/OpenPositionsController.cs
        region:17,43,17,48 - DS137138 [Moderate] - Insecure URL
        region:18,39,18,44 - DS137138 [Moderate] - Insecure URL
        region:19,32,19,37 - DS137138 [Moderate] - Insecure URL
        region:27,43,27,46 - DS126858 [Critical] - Weak/Broken Hash Algorithm

Issues found: 4 in 1 files
Files analyzed: 1
Files skipped: 0
```