### PR TITLE
Make use of ExitCode.IssuesExists for the analyze command

### DIFF
--- a/src/Microsoft.DevSkim/Microsoft.DevSkim.CLI/Commands/AnalyzeCommand.cs
+++ b/src/Microsoft.DevSkim/Microsoft.DevSkim.CLI/Commands/AnalyzeCommand.cs
@@ -228,7 +228,7 @@ namespace Microsoft.DevSkim.CLI.Commands
             Console.Error.WriteLine("Files analyzed: {0}", filesAnalyzed);
             Console.Error.WriteLine("Files skipped: {0}", filesSkipped);
 
-            return (int)ExitCode.NoIssues;
+            return issuesCount > 0 ? (int)ExitCode.IssuesExists : (int)ExitCode.NoIssues;
         }
 
         private bool ParseSeverity(string severityText, out Severity severity)


### PR DESCRIPTION
Fix for issue #71 

DevSkim CLI will now exit with ExitCode.IssuesExists when there are issues found.