### PR TITLE
Exception handling for file either empty or invalid dangling pointer

### DIFF
--- a/src/Microsoft.DevSkim/Microsoft.DevSkim.CLI/Commands/AnalyzeCommand.cs
+++ b/src/Microsoft.DevSkim/Microsoft.DevSkim.CLI/Commands/AnalyzeCommand.cs
@@ -193,8 +193,11 @@ namespace Microsoft.DevSkim.CLI.Commands
                 }
                 catch (Exception e)
                 {
-                    Console.Error.WriteLine("\nFile either empty or invalid dangling pointer.\n");
+                    // Skip files we can't parse
+                    filesSkipped++;
+                    continue;
                 }
+                
                 Issue[] issues = processor.Analyze(fileText, language);
 
                 if (issues.Count() > 0)

--- a/src/Microsoft.DevSkim/Microsoft.DevSkim.CLI/Commands/AnalyzeCommand.cs
+++ b/src/Microsoft.DevSkim/Microsoft.DevSkim.CLI/Commands/AnalyzeCommand.cs
@@ -185,8 +185,16 @@ namespace Microsoft.DevSkim.CLI.Commands
                     continue;
                 }
 
-                filesAnalyzed++;
-                string fileText = File.ReadAllText(filename);                
+                string fileText = string.Empty;
+                try
+                {
+                    fileText = File.ReadAllText(filename);
+                    filesAnalyzed++;
+                }
+                catch (Exception e)
+                {
+                    Console.Error.WriteLine("\nFile either empty or invalid dangling pointer.\n");
+                }
                 Issue[] issues = processor.Analyze(fileText, language);
 
                 if (issues.Count() > 0)


### PR DESCRIPTION
The application throws an exception in a Linux environment.

1. Create a shortcut for the file.
2. Remove the actual file.
3. Analyze the shortcut file.