### PR TITLE
Add official docker image

### DIFF
--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/runtimeconfig.template.json
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/runtimeconfig.template.json
@@ -1,0 +1,5 @@
+{
+    "configProperties": {
+      "System.Globalization.Invariant": true
+    }
+}

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.7
+
+COPY devskim /usr/bin/devskim
+
+ENTRYPOINT ["devskim"]
+CMD ["--help"]

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -2,6 +2,10 @@ FROM ubuntu:18.04
 
 COPY DevSkim-Linux /DevSkim-Linux
 
+RUN apt update
+
+RUN apt install libicu60 -y
+
 RUN ln -s /DevSkim-Linux/devskim /bin/devskim
 
 ENTRYPOINT ["devskim"]

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,6 +1,8 @@
-FROM alpine:3.7
+FROM ubuntu:18.04
 
-COPY devskim /usr/bin/devskim
+COPY publish /publish
+
+RUN ln -s /publish/devskim /bin/devskim
 
 ENTRYPOINT ["devskim"]
 CMD ["--help"]

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:18.04
 
-COPY publish /publish
+COPY DevSkim-Linux /DevSkim-Linux
 
-RUN ln -s /publish/devskim /bin/devskim
+RUN ln -s /DevSkim-Linux/devskim /bin/devskim
 
 ENTRYPOINT ["devskim"]
 CMD ["--help"]

--- a/Pipelines/devskim-core.yml
+++ b/Pipelines/devskim-core.yml
@@ -153,6 +153,31 @@ stages:
         ArtifactName: 'WinCoreArchives'
         publishLocation: 'Container'
 
+  - job: docker
+    displayName: Generate Docker Image
+    dependsOn:
+    - publish_nix
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+    - task: DownloadBuildArtifacts@0
+      inputs:
+        buildType: 'current'
+        downloadType: 'specific'
+        itemPattern: 'DevSkim_linux_'
+        downloadPath: '$(System.ArtifactsDirectory)'
+    - task: ExtractFiles@1
+      inputs:
+        archiveFilePatterns: '$(System.ArtifactsDirectory)/*.zip'
+        destinationFolder: '$(agent.builddirectory)/DevSkim-Linux'
+        cleanDestinationFolder: true
+    - task: Docker@2
+      inputs:
+        command: 'build'
+        Dockerfile: '$(build.sourcedirectory)/Docker/Dockerfile'
+        buildContext: '$(agent.builddirectory)/DevSkim-Linux'
+    
+    # TODO: Push docker image somewhere
 
   - job: hashes
     displayName: Generate Hashes

--- a/Pipelines/devskim-core.yml
+++ b/Pipelines/devskim-core.yml
@@ -165,17 +165,17 @@ stages:
         buildType: 'current'
         downloadType: 'specific'
         itemPattern: 'DevSkim_linux_'
-        downloadPath: '$(System.ArtifactsDirectory)'
+        downloadPath: '$(Agent.TempDirectory)'
     - task: ExtractFiles@1
       inputs:
-        archiveFilePatterns: '$(System.ArtifactsDirectory)/*.zip'
-        destinationFolder: '$(agent.builddirectory)/DevSkim-Linux'
+        archiveFilePatterns: '$(Agent.TempDirectory)/DevSkim_linux_*.zip'
+        destinationFolder: '$(Build.BinariesDirectory)/DevSkim-Linux'
         cleanDestinationFolder: true
     - task: Docker@2
       inputs:
         command: 'build'
-        Dockerfile: '$(build.sourcedirectory)/Docker/Dockerfile'
-        buildContext: '$(agent.builddirectory)/DevSkim-Linux'
+        Dockerfile: '$(Build.SourcesDirectory)/Docker/Dockerfile'
+        buildContext: '$(Build.BinariesDirectory)'
     
     # TODO: Push docker image somewhere
 


### PR DESCRIPTION
Fix #64.

This adds a Dockerfile for DevSkim and and the pipeline steps to build it. Missing are the set-up connections for a docker repository for pushing the image somewhere.  For now we just build it.