### PR TITLE
Fix - Conditions unable to find patterns in finding-region (VS Extension)

### DIFF
--- a/DevSkim-DotNet/Microsoft.DevSkim/RuleProcessor.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim/RuleProcessor.cs
@@ -123,7 +123,7 @@ namespace Microsoft.DevSkim
                                 {
                                     if (condition.Pattern is { })
                                     {
-                                        bool res = line.MatchPattern(condition.Pattern, match, condition);
+                                        bool res = textContainer.MatchPattern(condition.Pattern, translatedBoundary, condition);
                                         if (res && condition.NegateFinding)
                                         {
                                             passedConditions = false;


### PR DESCRIPTION
# Problem

- The VS engine does not calculate the correct boundary for the defined finding-region when searching for the condition pattern.

# Fixes

- Changed 'line' to 'textContainer' (content used to find the condition pattern)

- Changed 'match' to 'translatedBoundary' (boundary of the main pattern - starting character index and character length of the matched content)

# Why

- 'line' only contains the contents of the single line that the main pattern has matched on, therefore MatchPattern() will not be able to find the condition's pattern if the condition's pattern were on another line in the document. 'textContainer' contains the contents of the entire page which is cut down in MatchPattern() to the specified finding-region using Substring(), the contents of which is then used to determine whether the condition pattern is present within the specified finding-region.

- 'match' contains the boundary information of the main pattern in the context of only the line where it is present, however, the GetLocation() used by ParseSearchBoundary() in the TextContainer requires the boundary information of the pattern match in the context of the entire page. It is needed to determine the line number where the main pattern has matched, which is then used by BoundaryByLine() to determine the boundary information of the finding-region. This boundary information is returned to MatchPattern() for it to Substring the 'textContainer' to the specified finding-region. 'translatedBoundary' contains the boundary information of the pattern match in reference to the entire page, which is what I used as it had already been created and it's what we needed.