### PR TITLE
Fix - conditions are passing even if match is inside comment (Visual Studio)

### DIFF
--- a/DevSkim-DotNet/Microsoft.DevSkim/TextContainer.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim/TextContainer.cs
@@ -64,8 +64,19 @@ namespace Microsoft.DevSkim
 
             string text = _content.Substring(scope.Index, scope.Length);
             List<Boundary> matches = MatchPattern(pattern, text);
-            if (matches.Count > 0)
-                result = true;
+
+            foreach (Boundary match in matches)
+            {
+                Boundary translatedBoundary = new Boundary()
+                {
+                    Length = match.Length,
+                    Index = match.Index + scope.Index
+                };
+                if (ScopeMatch(pattern, translatedBoundary))
+                {
+                    result = true;
+                }
+            }
 
             return result;
         }


### PR DESCRIPTION
# Problem

- The VS engine passes conditions even if the match is commented

# Fixes

1. Updated MatchPattern() logic in TextContainer to run ScopeMatch() on all condition pattern 'matches'.

2. Creating a 'translatedBoundary' for each match

3. Setting 'result' to true if any of the matches are in scope

# Why

1. This ensures that the condition only passes if there is a match in scope (i.e. not commented)

2. 'translatedBoundary' contains the boundary information of the match in the context of the whole page, which is needed for ScopeMatch()

3. As long as there is one match in scope, the condition should pass
