### PR TITLE
Fix Output file inadvertently being opened 

### DIFF
--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
@@ -44,6 +44,8 @@ namespace Microsoft.DevSkim.CLI.Writers
 
             if (OutputPath is string)
             {
+                TextWriter.Close();
+                File.Delete(OutputPath);
                 sarifLog.Save(OutputPath);
             }
             else
@@ -57,10 +59,10 @@ namespace Microsoft.DevSkim.CLI.Writers
                 {
                     TextWriter.WriteLine(sr.ReadLine());
                 }
-            }
 
-            TextWriter.Flush();
-            TextWriter.Close();
+                TextWriter.Flush();
+                TextWriter.Close();
+            }
         }
 
         public override void WriteIssue(IssueRecord issue)


### PR DESCRIPTION
Output file was being opened ahead of time but that Writer can't be used by the SarifWriter due to API limitations.  The file was already opened so the call to `SarifLog.Save(path)` was failing because the file was already open.

Now close the file and delete it before trying to save there.

Fix #198