### PR TITLE
Replace all previous calls to the _rules field (deprecated) with the …

### DIFF
--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Catalogue.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Catalogue.cs
@@ -31,12 +31,12 @@ namespace Microsoft.DevSkim.CLI
                 }
                 sw.WriteLine(string.Join(",", lineItems));
 
-                foreach (Rule rule in _rules.AsEnumerable())
+                foreach (ConvertedOatRule rule in _rules.AsEnumerable())
                 {
                     lineItems.Clear();
                     foreach (string col in columnList)
                     {
-                        lineItems.Add(string.Format("\"{0}\"", GetProperty(rule, col)));
+                        lineItems.Add(string.Format("\"{0}\"", GetProperty(rule.DevSkimRule, col)));
                     }
 
                     sw.WriteLine(string.Join(",", lineItems));

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/PackCommand.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/PackCommand.cs
@@ -47,7 +47,7 @@ namespace Microsoft.DevSkim.CLI.Commands
             if (!verifier.Verify())
                 return (int)ExitCode.IssuesExists;
 
-            List<Rule> list = new List<Rule>(verifier.CompiledRuleset.AsEnumerable());
+            List<Rule> list = new List<Rule>(verifier.CompiledRuleset.AsEnumerable().Select(x => x.DevSkimRule));
 
             JsonSerializerSettings settings = new JsonSerializerSettings();
             settings.Formatting = (_indent) ? Formatting.Indented : Formatting.None;

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Tester.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Tester.cs
@@ -136,7 +136,7 @@ namespace Microsoft.DevSkim.CLI
             // See if file name is a valid rule ID and preload default values
             string defaultId = Path.GetFileNameWithoutExtension(fileName);
             string[]? languages = null;
-            Rule fileRule = _rules.FirstOrDefault(x => x.Id == defaultId);
+            Rule fileRule = _rules.Select(x => x.DevSkimRule).FirstOrDefault(x => x.Id == defaultId);
             if (fileRule != null)
                 languages = fileRule.AppliesTo;
 

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Tester.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Tester.cs
@@ -195,7 +195,7 @@ namespace Microsoft.DevSkim.CLI
                         foreach (string id in expecations[line])
                         {
                             string exists = string.Empty;
-                            if (_rules.FirstOrDefault(x => x.Id == id) == null)
+                            if (_rules.Select(x => x.DevSkimRule).FirstOrDefault(x => x.Id == id) == null)
                                 exists = " (no such rule) ";
 
                             Console.Error.WriteLine("\tline:{0} expecting {1}{2}", line, id, exists);

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Verifier.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Verifier.cs
@@ -83,7 +83,7 @@ namespace Microsoft.DevSkim.CLI
         {
             string[] languages = Language.GetNames();
 
-            foreach (Rule rule in _rules.AsEnumerable())
+            foreach (Rule rule in _rules.AsEnumerable().Select(x => x.DevSkimRule))
             {
                 // Check for null Id
                 if (rule.Id == null)

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Verifier.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Verifier.cs
@@ -93,8 +93,8 @@ namespace Microsoft.DevSkim.CLI
                 else
                 {
                     // Check for same ID
-                    Rule sameRule = _rules.FirstOrDefault(x => x.Id == rule.Id);
-                    if (_rules.Count(x => x.Id == rule.Id) > 1)
+                    Rule sameRule = _rules.Select(x => x.DevSkimRule).FirstOrDefault(x => x.Id == rule.Id);
+                    if (_rules.Count(x => x.DevSkimRule.Id == rule.Id) > 1)
                     {
                         _messages.Add(new ErrorMessage(Message: "Two or more rules have a same ID", RuleID: sameRule.Id, File: sameRule.Source, Warning: true));
 
@@ -158,7 +158,7 @@ namespace Microsoft.DevSkim.CLI
             rules.AddFile(file, null);
 
             if (noProblem)
-                _rules.AddRange(rules.AsEnumerable());
+                _rules.AddRange(rules.AsEnumerable().Select(x => x.DevSkimRule));
 
             return noProblem;
         }

--- a/DevSkim-DotNet/Microsoft.DevSkim/Ruleset.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim/Ruleset.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DevSkim
     /// <summary>
     ///     Storage for rules
     /// </summary>
-    public class RuleSet : IEnumerable<Rule>
+    public class RuleSet : IEnumerable<ConvertedOatRule>
     {
         /// <summary>
         ///     Creates instance of Ruleset
@@ -168,7 +168,7 @@ namespace Microsoft.DevSkim
         /// </summary>
         public int Count()
         {
-            return _rules.Count;
+            return _oatRules.Count;
         }
 
         public ConvertedOatRule? DevSkimRuleToConvertedOatRule(Rule rule)
@@ -289,16 +289,16 @@ namespace Microsoft.DevSkim
         /// <returns> Enumerator </returns>
         public IEnumerator GetEnumerator()
         {
-            return this._rules.GetEnumerator();
+            return this._oatRules.GetEnumerator();
         }
 
         /// <summary>
         ///     Returns an enumerator that iterates through the Ruleset
         /// </summary>
         /// <returns> Enumerator </returns>
-        IEnumerator<Rule> IEnumerable<Rule>.GetEnumerator()
+        IEnumerator<ConvertedOatRule> IEnumerable<ConvertedOatRule>.GetEnumerator()
         {
-            return this._rules.GetEnumerator();
+            return this._oatRules.GetEnumerator();
         }
 
         internal IEnumerable<Rule> StringToRules(string jsonstring, string sourcename, string? tag = null)
@@ -341,7 +341,6 @@ namespace Microsoft.DevSkim
         }
 
         private List<ConvertedOatRule> _oatRules;
-        private List<Rule> _rules;
         private Regex searchInRegex = new Regex("\\((.*),(.*)\\)", RegexOptions.Compiled);
 
         /// <summary>


### PR DESCRIPTION
…_oatRules field.

Fix #227 