### PR TITLE
Return non-zero ExitCode.IssuesExist when analyze finds issues

### DIFF
--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/AnalyzeCommand.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/AnalyzeCommand.cs
@@ -290,7 +290,7 @@ namespace Microsoft.DevSkim.CLI.Commands
             Debug.WriteLine("Files analyzed: {0}", filesAnalyzed);
             Debug.WriteLine("Files skipped: {0}", filesSkipped);
 
-            return (int)ExitCode.NoIssues;
+            return issuesCount == 0 ? (int)ExitCode.NoIssues : (int)ExitCode.IssuesExists;
         }
 
         private IEnumerable<FileEntry> FilenameToFileEntryArray(string x)


### PR DESCRIPTION
This fixes a regression in analyze command behavior.

I added the non-zero exit code when issues are found by the analyze command to make it easier to use in CI environments.

But it was changed back to always return a zero exit code in this commit https://github.com/microsoft/DevSkim/commit/7e53fb2059de40e08dbaec5674a64d48d0158537 by @gfs 

There isn't any real context in the commit message so I don't know if this was an intentional outcome or not.