### PR TITLE
Fix typos

### DIFF
--- a/guidance/DS121708.md
+++ b/guidance/DS121708.md
@@ -1,7 +1,7 @@
 ## Problematic C function detected (memcpy)
 
 ### Summary
-There are a number of conditions in which memcpy can introduce a vulnerability (mismatched buffer sizes, null pointers, etc.). More secure alternitives perform additional validation of the source and destination buffer
+There are a number of conditions in which memcpy can introduce a vulnerability (mismatched buffer sizes, null pointers, etc.). More secure alternatives perform additional validation of the source and destination buffer.
 
 ### Details
 TO DO - put more details of problem and solution here


### PR DESCRIPTION
I was just trying the VSCode plugin and received this warning. As there was the typo and a Github link I figured I'd quickly make this PR. It is as trivial as the commit title suggests.