### PR TITLE
Fix #264

### DIFF
--- a/DevSkim-DotNet/Microsoft.DevSkim.Blazor/Pages/Index.razor
+++ b/DevSkim-DotNet/Microsoft.DevSkim.Blazor/Pages/Index.razor
@@ -133,7 +133,7 @@
             // Blazor WASM doesn't support parallelization
             // https://github.com/dotnet/aspnetcore/issues/14253
             var cmd = new AnalyzeCommand(".", ".", "sarif", "", severities: new List<string>() { "manual", "critical", "important", "moderate" }, rules: new List<string>(),
-                ignoreDefault: false, suppressError: true, disableSuppression: true, crawlArchives: true, disableParallel: true);
+                ignoreDefault: false, suppressError: true, disableSuppression: true, crawlArchives: true, disableParallel: true, exitCodeIsNumIssues: false);
             var filename = Path.GetTempFileName();
             using var ms = new FileStream(filename, FileMode.Open);
             using var writer = new StreamWriter(ms);


### PR DESCRIPTION
Add the new command line option `-E` to output the number of issues as the exit code in Analyze Command.

Fixes #264.