### PR TITLE
Map the devskim levels to sarif levels

### DIFF
--- a/DevSkim-DotNet/Microsoft.DevSkim.Blazor/Pages/Index.razor
+++ b/DevSkim-DotNet/Microsoft.DevSkim.Blazor/Pages/Index.razor
@@ -132,7 +132,7 @@
 
             // Blazor WASM doesn't support parallelization
             // https://github.com/dotnet/aspnetcore/issues/14253
-            var cmd = new AnalyzeCommand(".", ".", "sarif", "", severities: new List<string>() { "manual", "critical", "important", "moderate" }, rules: new List<string>(),
+            var cmd = new AnalyzeCommand(".", ".", "sarif", "", severities: "manual,critical,important,moderate", rules: "",
                 ignoreDefault: false, suppressError: true, disableSuppression: true, crawlArchives: true, disableParallel: true, exitCodeIsNumIssues: false, globOptions: string.Empty);
             var filename = Path.GetTempFileName();
             using var ms = new FileStream(filename, FileMode.Open);

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
@@ -99,12 +99,14 @@ namespace Microsoft.DevSkim.CLI.Writers
                 resultItem.Fixes = GetFixits(issue);
 
             resultItem.Level = DevSkimLevelToSarifLevel(issue.Issue.Rule.Severity);
-            resultItem.Locations = new List<CodeAnalysis.Sarif.Location>();
-            resultItem.Locations.Add(loc);
+            resultItem.Locations = new List<CodeAnalysis.Sarif.Location>
+            {
+                loc
+            };
             _results.Push(resultItem);
         }
 
-        FailureLevel DevSkimLevelToSarifLevel(Severity severity) => severity switch
+        static FailureLevel DevSkimLevelToSarifLevel(Severity severity) => severity switch
         {
             var s when s.HasFlag(Severity.Critical) => FailureLevel.Error,
             var s when s.HasFlag(Severity.Important) => FailureLevel.Warning,

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
@@ -98,10 +98,21 @@ namespace Microsoft.DevSkim.CLI.Writers
             if (issue.Issue.Rule.Fixes != null)
                 resultItem.Fixes = GetFixits(issue);
 
+            resultItem.Level = DevSkimLevelToSarifLevel(issue.Issue.Rule.Severity);
             resultItem.Locations = new List<CodeAnalysis.Sarif.Location>();
             resultItem.Locations.Add(loc);
             _results.Push(resultItem);
         }
+
+        FailureLevel DevSkimLevelToSarifLevel(Severity severity) => severity switch
+        {
+            var s when s.HasFlag(Severity.Critical) => FailureLevel.Error,
+            var s when s.HasFlag(Severity.Important) => FailureLevel.Warning,
+            var s when s.HasFlag(Severity.Moderate) => FailureLevel.Warning,
+            var s when s.HasFlag(Severity.BestPractice) => FailureLevel.Note,
+            var s when s.HasFlag(Severity.ManualReview) => FailureLevel.Note,
+            _ => FailureLevel.None
+        };
 
         private ConcurrentStack<Result> _results = new ConcurrentStack<Result>();
 


### PR DESCRIPTION
Now report a severity level in the sarif output by mapping the devskim severity.