### PR TITLE
Always consider plaintext to be comments VS Code

### DIFF
--- a/DevSkim-VSCode-Plugin/server/src/utility_classes/document.ts
+++ b/DevSkim-VSCode-Plugin/server/src/utility_classes/document.ts
@@ -168,7 +168,7 @@ export class DocumentUtilities
         if (scopes.indexOf("all") > -1)
             return true;
 
-        let findingInComment: boolean = SourceContext.IsFindingInComment(langID, docContentsToFinding, newlineIndex);
+        let findingInComment: boolean = SourceContext.AlwaysCommented(langID) || SourceContext.IsFindingInComment(langID, docContentsToFinding, newlineIndex);
 
         for (let scope of scopes) 
         {

--- a/DevSkim-VSCode-Plugin/server/src/utility_classes/sourceContext.ts
+++ b/DevSkim-VSCode-Plugin/server/src/utility_classes/sourceContext.ts
@@ -170,6 +170,24 @@
     //Language specific code below here
 
     /**
+     * Informs if the language should always be considered to be comments and not code.
+     * 
+     * @private
+     * @param {string} langID VSCode language identifier (should be lower case)
+     * @returns {boolean} if the language should always be considered commented
+     */
+    public static AlwaysCommented(langId: string): boolean
+    {
+        switch(langId)
+        {
+            case "plaintext":
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /**
      * Retrieve the characters to start a comment in the given language (ex. "//" for C/C++/C#/Etc. )
      * 
      * @private


### PR DESCRIPTION
Should fix #344. Brings parity to the feature we recently added to .NET implementation.