### PR TITLE
Improve OpenSSL Cipher detection

### DIFF
--- a/Pipelines/templates/nbgv-set-version-steps.yml
+++ b/Pipelines/templates/nbgv-set-version-steps.yml
@@ -1,5 +1,5 @@
 steps:
-- script: 'dotnet tool install -g nbgv'
+- script: 'dotnet tool update -g nbgv'
   displayName: 'Install GitVersioning'
 - task: PowerShell@2
   displayName: Set Release Version

--- a/rules/default/security/cryptography/hardcoded_tls.json
+++ b/rules/default/security/cryptography/hardcoded_tls.json
@@ -89,7 +89,7 @@
                 "_comment": "OpenSSL extension / options"
             },
             {
-                "pattern": "(AES|DH|DHE|ADH|CAMELLIA|EDH|EXP|DES|IDEA|RC4|NULL|GOST|EXP|ECDH|ECDHE|AECDH|PSK)[A-Z0-9\\-]+-?(SHA|MD|GOST)[A-Z0-9\\-]*",
+                "pattern": "(AES|DH|DHE|ADH|CAMELLIA|EDH|EXP|DES|IDEA|RC4|NULL|GOST|EXP|ECDH|ECDHE|AECDH|PSK|SSL|RSA|TLS)_?([A-Z0-9]+_)+((SHA[0-9]*)|(MD5)|(GOST)[[A-Z0-9\\-]*)",
                 "type": "regex",
                 "scopes": [
                     "code"

--- a/rules/default/security/cryptography/hardcoded_tls.json
+++ b/rules/default/security/cryptography/hardcoded_tls.json
@@ -94,10 +94,52 @@
                 "scopes": [
                     "code"
                 ],
-                "_comment": "OpenSSL cipher suite"
+                "_comment": "OpenSSL constants"
             }
         ]
-    },    
+    },
+    {
+        "name": "OpenSSL: Do not hardcode SSL/TLS versions within an application.",
+        "id": "DS440011",
+        "description": "SSL/TLS version usage should be based on an OS or external configuration.",
+        "recommendation": "",
+        "does_not_apply_to": [
+            "json",
+            "yaml"
+        ],
+        "tags": [
+            "Cryptography.Protocol.TLS.Hardcoded"
+        ],
+        "severity": "important",
+        "_comment": "Applies to all languages since many just wrap OpenSSL constructs.",
+        "rule_info": "DS440000.md",
+        "patterns": [
+            {
+                "pattern": "(AES|DH|DHE|ADH|CAMELLIA|EDH|EXP|DES|IDEA|RC4|NULL|GOST|EXP|ECDH|ECDHE|AECDH|PSK)[A-Z0-9\\-]+-?(SHA|MD|GOST)[A-Z0-9\\-]*",
+                "type": "regex",
+                "modifiers":[ "i" ],
+                "scopes": [
+                    "code"
+                ],
+                "_comment": "OpenSSL external call"
+            }
+        ],
+        "conditions" : [
+            {
+                "pattern" : 
+                {
+                    "pattern": "openssl",
+                    "type": "regex",
+                    "modifiers":[ "i" ],
+                    "scopes": [
+                        "code"
+                    ]
+                },
+                "negate_finding": false,
+                "search_in": "finding-region(-5, 5)"
+            }
+        ]
+    }.
     {
         "name": ".NET - Do not hardcode SSL/TLS versions within an application.",
         "id": "DS440020",


### PR DESCRIPTION
Fix #374.

Improves the openssl cipher suite detection query.  It is still not perfect, but it should not longer have so many false positives. and should be readdressed in the larger refactor.

Here is the list of cipher suites which should be test cases:

https://www.openssl.org/docs/man1.1.1/man1/ciphers.html