### PR TITLE
Workaround for CWE-755 in Extension

### DIFF
--- a/DevSkim-DotNet/Microsoft.DevSkim.VSExtension/VSPackage.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.VSExtension/VSPackage.cs
@@ -5,6 +5,7 @@ using EnvDTE80;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using Newtonsoft.Json;
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -67,6 +68,7 @@ namespace Microsoft.DevSkim.VSExtension
         /// </summary>
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
+            JsonConvert.DefaultSettings = () => new JsonSerializerSettings { MaxDepth = 128 };
             await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
             base.Initialize();


### PR DESCRIPTION
The extension cannot currently be updated to 13.0.1 because it causes a crash on initialization with a Assembly not found exception. Use workaround to avoid potential Denial of Service.

https://github.com/JamesNK/Newtonsoft.Json/issues/2534