### PR TITLE
Support .NET 6 on DevSkim 0.6

### DIFF
--- a/DevSkim-DotNet/Microsoft.DevSkim.VSExtension/Microsoft.DevSkim.VSExtension.csproj
+++ b/DevSkim-DotNet/Microsoft.DevSkim.VSExtension/Microsoft.DevSkim.VSExtension.csproj
@@ -250,7 +250,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>16.11.35</Version>
+      <Version>17.4.2118</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Fix for pipeline issues with .net 6 on devskim 0.6