### PR TITLE
docs: use HTTPS for TLS encryption

### DIFF
--- a/guidance/DS137138.md
+++ b/guidance/DS137138.md
@@ -2,7 +2,7 @@
 
 ### Summary
 
-An HTTP-based URL without TLS was detected. If possible, change this to an HTTP-based URL to enforce transport-layer encryption.
+An HTTP-based URL without TLS was detected. If possible, change this to an HTTPS-based URL to enforce transport-layer encryption.
 
 ### Details
 


### PR DESCRIPTION
TLS connections are enforced with `https` and not `http`.