### PR TITLE
Updating prefix field in the comments.json

### DIFF
--- a/DevSkim-DotNet/Microsoft.DevSkim/resources/comments.json
+++ b/DevSkim-DotNet/Microsoft.DevSkim/resources/comments.json
@@ -18,7 +18,7 @@
       "php"
     ],
     "inline": "//",
-    "preffix": "/*",
+    "prefix": "/*",
     "suffix": "*/"
   },
   {
@@ -39,7 +39,7 @@
       "python"
     ],
     "inline": "#",
-    "preffix": "#",
+    "prefix": "#",
     "suffix": "\n"
   },
   {
@@ -48,7 +48,7 @@
       "sql"
     ],
     "inline": "--",
-    "preffix": "--",
+    "prefix": "--",
     "suffix": "\n"
   },
   {
@@ -56,7 +56,7 @@
       "clojure"
     ],
     "inline": ";;",
-    "preffix": ";;",
+    "prefix": ";;",
     "suffix": ""
   },
   {
@@ -64,7 +64,7 @@
       "vb"
     ],
     "inline": "'",
-    "preffix": "'",
+    "prefix": "'",
     "suffix": ""
   },
   {
@@ -72,7 +72,7 @@
       "batch"
     ],
     "inline": "::",
-    "preffix": "Rem",
+    "prefix": "Rem",
     "suffix": "\n"
   }
 ]


### PR DESCRIPTION
The current `comments.json` file as a typo in the `prefix` field. This means that the function `DevSkimLanguages.GetCommentPrefix` returns empty string.