### PR TITLE
CLI: output-format always required even if defaulted

### DIFF
--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/AnalyzeCommandOptions.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/AnalyzeCommandOptions.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.Design;
 using CommandLine;
 using Microsoft.ApplicationInspector.RulesEngine;
+using Microsoft.DevSkim.CLI.Writers;
 
 namespace Microsoft.DevSkim.CLI.Options;
 
@@ -14,7 +16,7 @@ public class AnalyzeCommandOptions
     public string Path { get; set; } = String.Empty;
     [Option('O',"output-file",Required = true, HelpText = "Filename for result file.")]
     public string OutputFile { get; set; } = String.Empty;
-    [Option('o', "output-format", HelpText = "Format for output text.")]
+    [Option('o', "output-format", HelpText = "Format for output text.", Default = SimpleTextWriter.DefaultFormat)]
     public string OutputTextFormat { get; set; } = String.Empty;
     [Option('f',"file-format", HelpText = "Format type for output. [text|sarif]", Default = "sarif")]
     public string OutputFileFormat { get; set; } = String.Empty;

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/AnalyzeCommandOptions.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/AnalyzeCommandOptions.cs
@@ -14,7 +14,7 @@ public class AnalyzeCommandOptions
     public string Path { get; set; } = String.Empty;
     [Option('O',"output-file",Required = true, HelpText = "Filename for result file.")]
     public string OutputFile { get; set; } = String.Empty;
-    [Option('o', "output-format", Required = false, HelpText = "Format for output text.")]
+    [Option('o', "output-format", HelpText = "Format for output text.")]
     public string OutputTextFormat { get; set; } = String.Empty;
     [Option('f',"file-format", HelpText = "Format type for output. [text|sarif]", Default = "sarif")]
     public string OutputFileFormat { get; set; } = String.Empty;

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/AnalyzeCommandOptions.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/AnalyzeCommandOptions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel.Design;
 using CommandLine;
 using Microsoft.ApplicationInspector.RulesEngine;
 using Microsoft.DevSkim.CLI.Writers;

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/AnalyzeCommandOptions.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/AnalyzeCommandOptions.cs
@@ -14,8 +14,7 @@ public class AnalyzeCommandOptions
     public string Path { get; set; } = String.Empty;
     [Option('O',"output-file",Required = true, HelpText = "Filename for result file.")]
     public string OutputFile { get; set; } = String.Empty;
-
-    [Option('o', "output-format", Required = true, HelpText = "Format for output text.")]
+    [Option('o', "output-format", Required = false, HelpText = "Format for output text.")]
     public string OutputTextFormat { get; set; } = String.Empty;
     [Option('f',"file-format", HelpText = "Format type for output. [text|sarif]", Default = "sarif")]
     public string OutputFileFormat { get; set; } = String.Empty;

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SimpleTextWriter.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SimpleTextWriter.cs
@@ -21,11 +21,13 @@ namespace Microsoft.DevSkim.CLI.Writers
     /// </summary>
     public class SimpleTextWriter : Writer
     {
+        public const string DefaultFormat = "%F:%L:%C:%l:%c [%S] %R %N";
+        
         private bool anyIssues = false;
         public SimpleTextWriter(string formatString, TextWriter writer)
         {
             if (string.IsNullOrEmpty(formatString))
-                _formatString = "%F:%L:%C:%l:%c [%S] %R %N";
+                _formatString = DefaultFormat;
             else
                 _formatString = formatString;
 


### PR DESCRIPTION
The `output-format` CLI arg is marked as required, but then is defaulted in the `SimpleTextWriter`:  
https://github.com/microsoft/DevSkim/blob/41f6af3a0d67ecff8b7ea78cbf7d2ea5f2a77856/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SimpleTextWriter.cs#L27-L28

This means that I have to *always* specify an output format when  I want to output into a text:
```bash
devskim analyze -I ./ -O analyze.log -o "%F:%L:%C:%l:%c [%S] %R %N" -f text
```

Am I missing something?