### PR TITLE
Minor fixes in suppression command

### DIFF
--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/SuppressionCommand.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/SuppressionCommand.cs
@@ -91,7 +91,7 @@ namespace Microsoft.DevSkim.CLI.Commands
                         }
 
                         var suppressionComment = isMultiline ? $"{ignoreComment}{theContent[zbStartLine]}{Environment.NewLine}" :
-                         $"{theContent[zbStartLine]}{ignoreComment}{Environment.NewLine}";
+                         $"{theContent[zbStartLine]} {ignoreComment}{Environment.NewLine}";
                         sb.Append(suppressionComment);
 
                         currLine = zbStartLine + 1;
@@ -143,7 +143,7 @@ namespace Microsoft.DevSkim.CLI.Commands
                     sb.Append($" until {expiration}");
                 }
 
-                sb.Append(devSkimLanguages.GetCommentSuffix(sourceLanguage));
+                sb.Append($" {devSkimLanguages.GetCommentSuffix(sourceLanguage)}");
                 return sb.ToString();
             }
         }


### PR DESCRIPTION
Fixing minor spaces in the suppressions-generated comments:

- `/*DevSkim ignore: DS12345 */` -> `/* DevSkim ignore: DS12345 */` 
- `host: localhost//DevSkim ignore: DS12345` -> `host: localhost //DevSkim ignore: DS12345`