### PR TITLE
Minor fixes in suppression command

### DIFF
--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/SuppressionCommand.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/SuppressionCommand.cs
@@ -37,16 +37,7 @@ namespace Microsoft.DevSkim.CLI.Commands
                 if (_opts.FilesToApplyTo.Any())
                 {
                     groupedResults =
-                        groupedResults.Where(x => _opts.FilesToApplyTo.Any(y => x.Key.ToString().Contains(y)));
-                }
-
-                // Exclude the files that do have any suppression matching the rules
-                if (_opts.RulesToApplyFrom.Any())
-                {
-                    groupedResults = groupedResults.Where(x =>
-                        _opts.RulesToApplyFrom.Any(y =>
-                            x.Any(z =>
-                                z.RuleId == y)));
+                        groupedResults.Where(grouping => _opts.FilesToApplyTo.Any(fileName => grouping.Key.ToString().Contains(fileName)));
                 }
 
                 groupedResults = groupedResults.ToList();
@@ -55,11 +46,11 @@ namespace Microsoft.DevSkim.CLI.Commands
                     var fileName = resultGroup.Key;
                     var potentialPath = Path.Combine(_opts.Path, fileName.OriginalString);
                     var issueRecords = resultGroup
-                      .Where(x => x.Locations is { })
-                      .SelectMany(x => x.Locations, (x, y) => new { x.RuleId, y.PhysicalLocation })
+                      .Where(result => result.Locations is { })
+                      .SelectMany(result => result.Locations, (x, y) => new { x.RuleId, y.PhysicalLocation })
                       .ToList();
 
-                    // Exclude the issues that do have any suppression matching the rules
+                    // Exclude the issues that do not have any suppression matching the rules
                     if (_opts.RulesToApplyFrom.Any())
                     {
                         issueRecords = issueRecords.Where(x => _opts.RulesToApplyFrom.Any(y => y == x.RuleId)).ToList();

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/SuppressionCommand.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/SuppressionCommand.cs
@@ -81,10 +81,7 @@ namespace Microsoft.DevSkim.CLI.Commands
                         Console.Error.WriteLine($"{potentialPath} specified in sarif does not appear to exist on disk.");
                     }
 
-                    var theContent = File.ReadAllText(potentialPath).Split(
-                        new string[] { "\r\n", "\r", "\n" },
-                        StringSplitOptions.None
-                    );
+                    var theContent = File.ReadAllLines(potentialPath);
                     int currLine = 0;
                     var sb = new StringBuilder();
 

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/SuppressionCommandOptions.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/SuppressionCommandOptions.cs
@@ -7,15 +7,15 @@ namespace Microsoft.DevSkim.CLI.Options;
 [Verb("suppressions", HelpText = "Apply suppressions from a Sarif")]
 public class SuppressionCommandOptions
 {
-    [Option('I',Required = true, HelpText = "Path to source code")]
+    [Option('I', Required = true, HelpText = "Path to source code")]
     public string Path { get; set; } = String.Empty;
-    [Option('O',Required = true, HelpText = "Filename for sarif with DevSkim scan results.")]
+    [Option('O', Required = true, HelpText = "Filename for sarif with DevSkim scan results.")]
     public string SarifInput { get; set; } = String.Empty;
     [Option("dry-run", HelpText = "Print information about files that would be changed without changing them.")]
     public bool DryRun { get; set; }
     [Option("all", HelpText = "Apply all ignore.")]
     public bool ApplyAllSuppression { get; set; }
-    [Option("files", HelpText = "Comma separated list of paths to apply ignore to to", Separator = ',')]
+    [Option("files", HelpText = "Comma separated list of paths to apply ignore to", Separator = ',')]
     public IEnumerable<string> FilesToApplyTo { get; set; } = Array.Empty<string>();
     [Option("rules", HelpText = "Comma separated list of rules to apply ignore for", Separator = ',')]
     public IEnumerable<string> RulesToApplyFrom { get; set; } = Array.Empty<string>();

--- a/DevSkim-DotNet/Microsoft.DevSkim.Tests/SuppressionsTest.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.Tests/SuppressionsTest.cs
@@ -15,10 +15,11 @@ namespace Microsoft.DevSkim.Tests
         [DataRow(false)]
         public void ExecuteSuppressions(bool preferMultiLine)
         {
-            (string basePath, string sourceFile, string sarifPath)  = runAnalysis(@"MD5;
+            (string basePath, string sourceFile, string sarifPath) = runAnalysis(@"MD5;
             http://", "c");
 
-            var opts = new SuppressionCommandOptions{
+            var opts = new SuppressionCommandOptions
+            {
                 Path = basePath,
                 SarifInput = sarifPath,
                 ApplyAllSuppression = true,
@@ -41,9 +42,10 @@ namespace Microsoft.DevSkim.Tests
         [DataRow(false)]
         public void ExecuteMultipleSuppressionsInOneLine(bool preferMultiLineFormat)
         {
-            (string basePath, string sourceFile, string sarifPath)  = runAnalysis(@"MD5;http://", "c");
+            (string basePath, string sourceFile, string sarifPath) = runAnalysis(@"MD5;http://", "c");
 
-            var opts = new SuppressionCommandOptions{
+            var opts = new SuppressionCommandOptions
+            {
                 Path = basePath,
                 SarifInput = sarifPath,
                 ApplyAllSuppression = true,
@@ -58,15 +60,41 @@ namespace Microsoft.DevSkim.Tests
             Assert.AreEqual("DS137138", firstLineSuppression.GetSuppressedIds[0]);
             Assert.AreEqual("DS126858", firstLineSuppression.GetSuppressedIds[1]);
         }
-        
+
+        [DataTestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public void ExecuteSuppressionsOnlyForSpecifiedRules(bool preferMultiLineFormat)
+        {
+            (string basePath, string sourceFile, string sarifPath) = runAnalysis(@"MD5;http://", "c");
+
+            var opts = new SuppressionCommandOptions
+            {
+                Path = basePath,
+                SarifInput = sarifPath,
+                ApplyAllSuppression = true,
+                PreferMultiline = preferMultiLineFormat,
+                RulesToApplyFrom = new string[] { "DS137138" }
+            };
+
+            var resultCode = new SuppressionCommand(opts).Run();
+            Assert.AreEqual(0, resultCode);
+            var result = File.ReadAllLines(sourceFile);
+            var firstLineSuppression = new Suppression(result[0]);
+            Assert.IsTrue(firstLineSuppression.IsInEffect);
+            Assert.AreEqual("DS137138", firstLineSuppression.GetSuppressedIds[0]);
+            Assert.AreEqual(1, firstLineSuppression.GetSuppressedIds.Length);
+        }
+
         [DataTestMethod]
         [DataRow(true)]
         [DataRow(false)]
         public void ExecuteSuppressionsWithExpiration(bool preferMultiLineFormat)
         {
-            (string basePath, string sourceFile, string sarifPath)  = runAnalysis(@"MD5;http://", "c");
+            (string basePath, string sourceFile, string sarifPath) = runAnalysis(@"MD5;http://", "c");
 
-            var opts = new SuppressionCommandOptions{
+            var opts = new SuppressionCommandOptions
+            {
                 Path = basePath,
                 SarifInput = sarifPath,
                 ApplyAllSuppression = true,
@@ -89,10 +117,11 @@ namespace Microsoft.DevSkim.Tests
         [DataRow(false)]
         public void NotExecuteSuppressions(bool preferMultiLine)
         {
-            (string basePath, string sourceFile, string sarifPath)  = runAnalysis(@"MD5;
+            (string basePath, string sourceFile, string sarifPath) = runAnalysis(@"MD5;
             http://", "c");
 
-            var opts = new SuppressionCommandOptions{
+            var opts = new SuppressionCommandOptions
+            {
                 Path = basePath,
                 SarifInput = sarifPath,
                 PreferMultiline = preferMultiLine
@@ -107,10 +136,11 @@ namespace Microsoft.DevSkim.Tests
         [TestMethod]
         public void ExecuteDryRun()
         {
-            (string basePath, string sourceFile, string sarifPath)  = runAnalysis(@"MD5;
+            (string basePath, string sourceFile, string sarifPath) = runAnalysis(@"MD5;
             http://", "c");
 
-            var opts = new SuppressionCommandOptions{
+            var opts = new SuppressionCommandOptions
+            {
                 Path = basePath,
                 SarifInput = sarifPath,
                 ApplyAllSuppression = true,
@@ -126,14 +156,15 @@ namespace Microsoft.DevSkim.Tests
         [TestMethod]
         public void ExecuteSuppressionsOnSpecificFiles()
         {
-            (string basePath, string sourceFile, string sarifPath)  = runAnalysis(@"MD5;
+            (string basePath, string sourceFile, string sarifPath) = runAnalysis(@"MD5;
             http://", "c");
 
-            var opts = new SuppressionCommandOptions{
+            var opts = new SuppressionCommandOptions
+            {
                 Path = basePath,
                 SarifInput = sarifPath,
                 ApplyAllSuppression = true,
-                FilesToApplyTo = new string[]{"/tmp/not-existing.c"}
+                FilesToApplyTo = new string[] { "/tmp/not-existing.c" }
             };
 
             var resultCode = new SuppressionCommand(opts).Run();
@@ -147,11 +178,12 @@ namespace Microsoft.DevSkim.Tests
         [DataRow(false)]
         public void ExecuteSuppresionsForMultilineFormattedFiles(bool preferMultiLine)
         {
-            (string basePath, string sourceFile, string sarifPath)  = runAnalysis(@"MD5 \
+            (string basePath, string sourceFile, string sarifPath) = runAnalysis(@"MD5 \
             Test;
             http://", "c");
 
-            var opts = new SuppressionCommandOptions{
+            var opts = new SuppressionCommandOptions
+            {
                 Path = basePath,
                 SarifInput = sarifPath,
                 ApplyAllSuppression = true,
@@ -169,7 +201,8 @@ namespace Microsoft.DevSkim.Tests
             Assert.AreEqual("DS137138", secondLineSuppression.GetSuppressedIds.First());
         }
 
-        private (string basePath, string sourceFile, string sarifPath) runAnalysis(string content, string ext) {
+        private (string basePath, string sourceFile, string sarifPath) runAnalysis(string content, string ext)
+        {
             var tempFileName = $"{Path.GetTempFileName()}.{ext}";
             var outFileName = Path.GetTempFileName();
             File.Delete(outFileName);

--- a/DevSkim-DotNet/Microsoft.DevSkim/Suppression.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim/Suppression.cs
@@ -99,7 +99,7 @@ namespace Microsoft.DevSkim
         }
 
         public string[] GetSuppressedIds => _issues.Select(x => x.ID ?? string.Empty).Where(x => !string.IsNullOrEmpty(x)).ToArray();
-        
+
         protected const string KeywordAll = "all";
         protected const string KeywordIgnore = "ignore";
         protected const string KeywordPrefix = "DevSkim:";


### PR DESCRIPTION
Including some changes to fix the following:
- `--rules` is not working properly. In case a file has multiple suppressions, the command should apply only the suppressions specified by the `rules` flag (if any).
- Suppression command is not reading `CRLF` and `LF`. In case of mixed termination files, it was adding the comment in a new line. Now the control characters are read correctly.