### PR TITLE
Add options to analyze to specify ruleids

### DIFF
--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/AnalyzeCommand.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/AnalyzeCommand.cs
@@ -182,6 +182,16 @@ namespace Microsoft.DevSkim.CLI.Commands
                     return (int)ExitCode.CriticalError;
                 }
             }
+
+            if (opts.RuleIds.Any())
+            {
+                devSkimRuleSet = devSkimRuleSet.WithIds(opts.RuleIds);
+            }
+
+            if (opts.IgnoreRuleIds.Any())
+            {
+                devSkimRuleSet = devSkimRuleSet.WithoutIds(opts.IgnoreRuleIds);
+            }
             
             if (!devSkimRuleSet.Any())
             {

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/AnalyzeCommandOptions.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/AnalyzeCommandOptions.cs
@@ -11,6 +11,10 @@ public class AnalyzeCommandOptions
 {
     [Option('r', HelpText = "Comma separated list of paths to rules files to use", Separator = ',')]
     public IEnumerable<string> Rules { get; set; } = Array.Empty<string>();
+    [Option("rule-ids", HelpText = "Comma separated list of rule IDs to limit analysis to", Separator = ',')]
+    public IEnumerable<string> RuleIds { get; set; } = Array.Empty<string>();
+    [Option("ignore-rule-ids", HelpText = "Comma separated list of rule IDs to ignore", Separator = ',')]
+    public IEnumerable<string> IgnoreRuleIds { get; set; } = Array.Empty<string>();
     [Option('I',Required = true, HelpText = "Path to source code")]
     public string Path { get; set; } = String.Empty;
     [Option('O',"output-file",Required = true, HelpText = "Filename for result file.")]

--- a/DevSkim-DotNet/Microsoft.DevSkim.Tests/Microsoft.DevSkim.Tests.csproj
+++ b/DevSkim-DotNet/Microsoft.DevSkim.Tests/Microsoft.DevSkim.Tests.csproj
@@ -9,10 +9,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-        <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-        <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-        <PackageReference Include="coverlet.collector" Version="3.1.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+        <PackageReference Include="coverlet.collector" Version="3.2.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/DevSkim-DotNet/Microsoft.DevSkim/DevSkimRuleSet.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim/DevSkimRuleSet.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (C) Microsoft. All rights reserved. Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -19,10 +20,14 @@ namespace Microsoft.DevSkim
         {
         }
 
+        /// <summary>
+        /// Load the default rules embedded in the DevSkim binary
+        /// </summary>
+        /// <returns>A <see cref="DevSkimRuleSet"/> </returns>
         public static DevSkimRuleSet GetDefaultRuleSet()
         {
             DevSkimRuleSet ruleSet = new DevSkimRuleSet();
-            Assembly assembly = Assembly.GetExecutingAssembly();
+            Assembly assembly = ruleSet.GetType().Assembly;
             string[] resNames = Assembly.GetExecutingAssembly().GetManifestResourceNames();
             foreach (string resName in resNames.Where(x => x.StartsWith("Microsoft.DevSkim.rules.default") && x.EndsWith(".json")))
             {
@@ -33,6 +38,31 @@ namespace Microsoft.DevSkim
             }
 
             return ruleSet;
+        }
+
+        /// <summary>
+        /// Returns a new <see cref="DevSkimRuleSet"/> with only rules that have an ID matching one of the ids provided in <paramref name="ruleIds"/>
+        /// </summary>
+        /// <param name="ruleIds"></param>
+        /// <returns></returns>
+        public DevSkimRuleSet WithIds(IEnumerable<string> ruleIds)
+        {
+            var newSet = new DevSkimRuleSet();
+            newSet.AddRange(this.Where(x => ruleIds.Contains(x.Id)));
+            return newSet;
+        }
+
+        /// <summary>
+        /// Returns a new <see cref="DevSkimRuleSet"/> with no rules that have an ID matching one of the ids provided in <paramref name="optsIgnoreRuleIds"/>
+        /// </summary>
+        /// <param name="optsIgnoreRuleIds"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
+        public DevSkimRuleSet WithoutIds(IEnumerable<string> optsIgnoreRuleIds)
+        {
+            var newSet = new DevSkimRuleSet();
+            newSet.AddRange(this.Where(x => !optsIgnoreRuleIds.Contains(x.Id)));
+            return newSet;
         }
     }
 }

--- a/DevSkim-DotNet/Microsoft.DevSkim/Microsoft.DevSkim.csproj
+++ b/DevSkim-DotNet/Microsoft.DevSkim/Microsoft.DevSkim.csproj
@@ -25,8 +25,8 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.CST.ApplicationInspector.RulesEngine" Version="1.6.19" />
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-      <PackageReference Include="System.Text.Json" Version="6.0.5" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+      <PackageReference Include="System.Text.Json" Version="7.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning">
-      <Version>3.5.109</Version>
+      <Version>3.5.119</Version>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
Adds two options, `rule-ids` to limit analysis to only the rule ids provided and `ignore-rule-ids` to prevent using rules with matching ids and simple tests for each.

Fix #444