### PR TITLE
Fix #426

### DIFF
--- a/rules/default/security/TLS/tls_generic.json
+++ b/rules/default/security/TLS/tls_generic.json
@@ -26,6 +26,20 @@
                 "modifiers" : ["i"],
                 "_comment": "Generic reference to a SSL/TLS version"
             }
+        ],
+        "conditions" : [
+            {
+                "pattern" :
+                {
+                    "pattern": "--tlsv1.3",
+                    "type": "string",
+                    "scopes": [
+                        "code"
+                    ]
+                },
+                "negate_finding": true,
+                "search_in": "same-line"
+            }
         ]
     },
     {
@@ -220,7 +234,49 @@
                 "_comment": "mbedTLS functions that implement specific protocol versions"
             }            
         ]
-    },          
+    },
+    {
+        "name": "Generic: Hard-coded SSL/TLS Protocol",
+        "id": "DS440016",
+        "description": "Curl: Hard-coded SSL/TLS Protocol",
+        "recommendation": "Review to ensure that a TLS protocol agility is maintained.",
+        "overrides": [
+            "DS440000"
+        ],
+        "does_not_apply_to": [
+            "json",
+            "yaml"
+        ],
+        "tags": [
+            "Cryptography.Protocol.TLS.Hard-Coded"
+        ],
+        "severity": "ManualReview",
+        "rule_info": "DS440000.md",
+        "patterns": [
+            {
+                "pattern": "--(sslv2|sslv3|tlsv1|tlsv11|tlsv1\\.1|tlsv1\\.2)",
+                "type": "regex",
+                "scopes": [
+                    "code"
+                ],
+                "_comment": "curl"
+            }
+        ],
+        "conditions" : [
+            {
+                "pattern" :
+                {
+                    "pattern": "--tlsv1.3",
+                    "type": "substring",
+                    "scopes": [
+                        "code"
+                    ]
+                },
+                "negate_finding": true,
+                "search_in": "same-line"
+            }
+        ]
+    },
     {
         "name": "Generic: Hard-coded SSL/TLS Protocol",
         "id": "DS440016",
@@ -246,14 +302,6 @@
                     "code"
                 ],
                 "_comment": "wget"
-            },
-            {
-                "pattern": "--(sslv2|sslv3|tlsv1|tlsv11|tlsv1\\.1|tlsv1\\.2)",
-                "type": "regex",
-                "scopes": [
-                    "code"
-                ],
-                "_comment": "curl"
             },
             {
                 "pattern": "CURL_SSLVERSION_(MAX_)?(SSL|TLS)v[0123_]+",

--- a/rules/default/security/cryptography/hardcoded_tls.json
+++ b/rules/default/security/cryptography/hardcoded_tls.json
@@ -23,7 +23,21 @@
                 "modifiers" : ["i"],
                 "_comment": "Generic reference to a SSL/TLS version"
             }
-        ]
+        ],
+        "conditions" : [
+        {
+            "pattern" :
+            {
+                "pattern": "--tlsv1.3",
+                "type": "substring",
+                "scopes": [
+                    "code"
+                ]
+            },
+            "negate_finding": true,
+            "search_in": "same-line"
+        }
+    ]
     },    
     {
         "name": "OpenSSL: Do not hardcode SSL/TLS versions within an application.",


### PR DESCRIPTION
Should not show an issue when calling curl --tls1.3 per filed issue as that indicates a minimum version level, and any available higher version will be used.