### PR TITLE
Fixes DevSkim Severity reporting

### DIFF
--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
@@ -130,7 +130,7 @@ namespace Microsoft.DevSkim.CLI.Writers
             {
                 loc
             };
-            resultItem.SetProperty<Severity>("DevSkimSeverity", issue.Issue.Rule.Severity);
+            resultItem.SetProperty("DevSkimSeverity", issue.Issue.Rule.Severity.ToString());
             _results.Push(resultItem);
         }
 


### PR DESCRIPTION
Was printing the enum numerical value rather than the string.