### PR TITLE
Rewrite Visual Studio Extension to use Language Server

### DIFF
--- a/DevSkim-DotNet/Microsoft.DevSkim.LanguageServer/Microsoft.DevSkim.LanguageServer.csproj
+++ b/DevSkim-DotNet/Microsoft.DevSkim.LanguageServer/Microsoft.DevSkim.LanguageServer.csproj
@@ -5,10 +5,11 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>DevSkim.LanguageServer</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.CST.ApplicationInspector.RulesEngine" Version="1.7.3" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.5" />

--- a/DevSkim-DotNet/Microsoft.DevSkim.LanguageServer/Program.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.LanguageServer/Program.cs
@@ -84,13 +84,13 @@ internal class Program
 								new WorkDoneProgressBegin { Title = "Beginning server routines..." }).ConfigureAwait(false);
 
 
-							IConfiguration configuration = await languageServer.Configuration.GetConfiguration(
-								new ConfigurationItem
-								{
-									Section = ConfigHelpers.Section
-								}
-							).ConfigureAwait(false);
-							ConfigHelpers.SetScannerSettings(configuration);
+							//IConfiguration configuration = await languageServer.Configuration.GetConfiguration(
+							//	new ConfigurationItem
+							//	{
+							//		Section = ConfigHelpers.Section
+							//	}
+							//).ConfigureAwait(false);
+							//ConfigHelpers.SetScannerSettings(configuration);
 							Log.Logger.Debug("Listening for client events...");
 						}
 					)

--- a/DevSkim-DotNet/Microsoft.DevSkim.LanguageServer/StaticScannerSettings.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.LanguageServer/StaticScannerSettings.cs
@@ -15,13 +15,13 @@
         internal static string ReviewerName { get; set; } = string.Empty;
         // Suppression duration in days
         internal static int SuppressionDuration { get; set; } = 30;
-        internal static bool IgnoreDefaultRuleSet { get; set; }
-        internal static bool ScanOnOpen { get; set; }
-        internal static bool ScanOnSave { get; set; }
-        internal static bool ScanOnChange { get; set; }
-        internal static bool RemoveFindingsOnClose { get; set; }
+        internal static bool IgnoreDefaultRuleSet { get; set; } = false;
+        internal static bool ScanOnOpen { get; set; } = true;
+        internal static bool ScanOnSave { get; set; } = true;
+        internal static bool ScanOnChange { get; set; } = true;
+        internal static bool RemoveFindingsOnClose { get; set; } = true;
         internal static DevSkimRuleSet RuleSet { get; set; } = new DevSkimRuleSet();
         internal static DevSkimRuleProcessorOptions RuleProcessorOptions { get; set; } = new DevSkimRuleProcessorOptions();
-        internal static DevSkimRuleProcessor Processor { get; set; } = new DevSkimRuleProcessor(new DevSkimRuleSet(), new DevSkimRuleProcessorOptions());
+        internal static DevSkimRuleProcessor Processor { get; set; } = new DevSkimRuleProcessor(DevSkimRuleSet.GetDefaultRuleSet(), new DevSkimRuleProcessorOptions());
     }
 }

--- a/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio/ContentTypes.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio/ContentTypes.cs
@@ -1,0 +1,19 @@
+﻿namespace Microsoft.DevSkim.VisualStudio
+{
+    using Microsoft.VisualStudio.LanguageServer.Client;
+    using Microsoft.VisualStudio.Utilities;
+    using System.ComponentModel.Composition;
+
+    public class JsonContentType
+    {
+        [Export]
+        [Name("json")]
+        [BaseDefinition(CodeRemoteContentDefinition.CodeRemoteContentTypeName)]
+        internal static ContentTypeDefinition JsonContentTypeDefinition;
+
+        [Export]
+        [FileExtension(".json")]
+        [ContentType("json")]
+        internal static FileExtensionToContentTypeDefinition JsonFileExtensionDefinition;
+    }
+}

--- a/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio/DevSkimLanguageClient.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio/DevSkimLanguageClient.cs
@@ -1,0 +1,139 @@
+﻿using Microsoft.VisualStudio.LanguageServer.Client;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Utilities;
+using StreamJsonRpc;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Pipes;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+using Newtonsoft.Json.Linq;
+using Task = System.Threading.Tasks.Task;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using System.ComponentModel.Composition;
+using Microsoft.Build.Framework.XamlTypes;
+
+namespace Microsot.DevSkim.LanguageClient
+{
+    // TODO: Test if code type also covers things like .json
+    [ContentType("code")]
+    [Export(typeof(ILanguageClient))]
+    public class DevSkimLanguageClient : ILanguageClient
+    {
+        public DevSkimLanguageClient()
+        {
+            Instance = this;
+        }
+
+        internal static DevSkimLanguageClient Instance
+        {
+            get;
+            set;
+        }
+
+        internal JsonRpc Rpc
+        {
+            get;
+            set;
+        }
+
+        public event AsyncEventHandler<EventArgs> StartAsync;
+        public event AsyncEventHandler<EventArgs> StopAsync;
+
+        public string Name => "DevSkim Language Extension";
+
+        public IEnumerable<string> ConfigurationSections => null;
+
+        public object InitializationOptions => null;
+
+        public IEnumerable<string> FilesToWatch => null;
+
+        public bool ShowNotificationOnInitializeFailed => true;
+
+        public async Task<Connection> ActivateAsync(CancellationToken token)
+        {
+            await Task.Yield();
+            ProcessStartInfo info = new ProcessStartInfo();
+            info.FileName = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Server", @"Microsoft.DevSkim.LanguageServer.exe");
+            info.RedirectStandardInput = true;
+            info.RedirectStandardOutput = true;
+            info.UseShellExecute = false;
+            info.CreateNoWindow = true;
+
+            Process process = new Process();
+            process.StartInfo = info;
+
+            if (process.Start())
+            {
+                return new Connection(process.StandardOutput.BaseStream, process.StandardInput.BaseStream);
+            }
+
+            return null;
+        }
+
+        public async Task OnLoadedAsync()
+        {
+            if (StartAsync != null)
+            {
+                await StartAsync.InvokeAsync(this, EventArgs.Empty);
+            }
+        }
+
+        public async Task StopServerAsync()
+        {
+            if (StopAsync != null)
+            {
+                await StopAsync.InvokeAsync(this, EventArgs.Empty);
+            }
+        }
+
+        public Task OnServerInitializedAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task AttachForCustomMessageAsync(JsonRpc rpc)
+        {
+            this.Rpc = rpc;
+
+            return Task.CompletedTask;
+        }
+
+        public Task<InitializationFailureContext> OnServerInitializeFailedAsync(ILanguageClientInitializationInfo initializationState)
+        {
+            string message = "DevSkim Language Client failed to activate.";
+            string exception = initializationState.InitializationException?.ToString() ?? string.Empty;
+            message = $"{message}\n {exception}";
+
+            var failureContext = new InitializationFailureContext()
+            {
+                FailureMessage = message,
+            };
+
+            return Task.FromResult(failureContext);
+        }
+
+        internal class FooMiddleLayer : ILanguageClientMiddleLayer
+        {
+            public bool CanHandle(string methodName)
+            {
+                return methodName == Methods.TextDocumentCompletionName;
+            }
+
+            public Task HandleNotificationAsync(string methodName, JToken methodParam, Func<JToken, Task> sendNotification)
+            {
+                throw new NotImplementedException();
+            }
+
+            public async Task<JToken> HandleRequestAsync(string methodName, JToken methodParam, Func<JToken, Task<JToken>> sendRequest)
+            {
+                var result = await sendRequest(methodParam);
+                return result;
+            }
+        }
+    }
+}

--- a/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio/Microsoft.DevSkim.VisualStudio.csproj
+++ b/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio/Microsoft.DevSkim.VisualStudio.csproj
@@ -1,0 +1,116 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>17.0</MinimumVisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{E7A5F71D-137D-4D65-AB27-2ADD1FA6B26B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Microsoft.DevSkim.VisualStudio</RootNamespace>
+    <AssemblyName>Microsoft.DevSkim.VisualStudio</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <GeneratePkgDefFile>true</GeneratePkgDefFile>
+    <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
+    <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
+    <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
+    <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
+    <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
+    <StartAction>Program</StartAction>
+    <StartProgram Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix Exp</StartArguments>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ContentTypes.cs" />
+    <Compile Include="DevSkimLanguageClient.cs" />
+    <Compile Include="RuleOptionPageGrid.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="OptionPageGrid.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="OptionPackage.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="source.extension.vsixmanifest">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Client">
+      <Version>17.5.62</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol">
+      <Version>17.2.8</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.5.33428.388" ExcludeAssets="runtime">
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.5.4065" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Design" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xaml" />
+    <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <!-- Publish the language server binaries for Release -->
+  <Target Name="BuildLanguageServer" BeforeTargets="IncludeLanguageServer" Condition=" '$(Configuration)' == 'Release' ">
+    <Exec Command="dotnet publish -f net7.0 -c Release ..\Microsoft.DevSkim.LanguageServer -r win-x86 --sc" />
+  </Target>
+  <!-- Include the published language server binaries for Release -->
+  <Target Name="IncludeLanguageServer" BeforeTargets="GetVsixSourceItems" Condition=" '$(Configuration)' == 'Release' ">
+    <ItemGroup>
+      <Content Include="..\Microsoft.DevSkim.LanguageServer\bin\Release\net7.0\win-x86\publish\*.*" Visible="false">
+        <IncludeInVSIX>true</IncludeInVSIX>
+        <VsixSubPath>Server</VsixSubPath>
+      </Content>
+    </ItemGroup>
+  </Target>
+  <!-- Publish the language server binaries for Debug -->
+  <Target Name="BuildLanguageServerDebug" BeforeTargets="IncludeLanguageServerDebug" Condition=" '$(Configuration)' == 'Debug' ">
+    <Exec Command="dotnet publish -f net7.0 -c Debug ..\Microsoft.DevSkim.LanguageServer -r win-x86 --sc" />
+  </Target>
+  <!-- Include the published language server binaries for Debug -->
+  <Target Name="IncludeLanguageServerDebug" BeforeTargets="GetVsixSourceItems" Condition=" '$(Configuration)' == 'Debug' ">
+    <ItemGroup>
+      <Content Include="..\Microsoft.DevSkim.LanguageServer\bin\Debug\net7.0\win-x86\publish\*.*" Visible="false">
+        <IncludeInVSIX>true</IncludeInVSIX>
+        <VsixSubPath>Server</VsixSubPath>
+      </Content>
+    </ItemGroup>
+  </Target>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio/OptionPackage.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio/OptionPackage.cs
@@ -1,0 +1,75 @@
+﻿namespace Microsoft.DevSkim.VisualStudio
+{
+    using Microsoft.VisualStudio;
+    using Microsoft.VisualStudio.OLE.Interop;
+    using Microsoft.VisualStudio.Shell;
+    using Microsoft.VisualStudio.Shell.Interop;
+    using Microsoft.Win32;
+    using System;
+    using System.ComponentModel.Design;
+    using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Globalization;
+    using System.Runtime.InteropServices;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Task = System.Threading.Tasks.Task;
+
+    /// <summary>
+    /// This is the class that implements the package exposed by this assembly.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The minimum requirement for a class to be considered a valid package for Visual Studio
+    /// is to implement the IVsPackage interface and register itself with the shell.
+    /// This package uses the helper classes defined inside the Managed Package Framework (MPF)
+    /// to do it: it derives from the Package class that provides the implementation of the
+    /// IVsPackage interface and uses the registration attributes defined in the framework to
+    /// register itself and its components with the shell. These attributes tell the pkgdef creation
+    /// utility what data to put into .pkgdef file.
+    /// </para>
+    /// <para>
+    /// To get loaded into VS, the package must be referred by &lt;Asset Type="Microsoft.VisualStudio.VsPackage" ...&gt; in .vsixmanifest file.
+    /// </para>
+    /// </remarks>
+    [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
+    [InstalledProductRegistration("#110", "#112", "1.0", IconResourceID = 400)] // Info on this package for Help/About
+    [ProvideMenuResource("Menus.ctmenu", 1)]
+    [Guid(PackageGuidString)]
+    [ProvideOptionPage(typeof(OptionPageGrid),
+    "DevSkim", "Scan Configuration", 0, 0, true)]
+    [ProvideOptionPage(typeof(RuleOptionPageGrid),
+    "DevSkim", "Rule Options", 0, 0, true)]
+    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "pkgdef, VS and vsixmanifest are valid VS terms")]
+    public sealed class OptionPackage : AsyncPackage
+    {
+        /// <summary>
+        /// ToolWindow1Package GUID string.
+        /// </summary>
+        public const string PackageGuidString = "ef3feecc-7c99-42f5-aa32-95c3b0d389aa";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OptionPackage"/> class.
+        /// </summary>
+        public OptionPackage()
+        {
+            // Inside this method you can place any initialization code that does not require
+            // any Visual Studio service because at this point the package object is created but
+            // not sited yet inside Visual Studio environment. The place to do all the other
+            // initialization is the Initialize method.
+        }
+
+        public bool OptionInteger
+        {
+            get
+            {
+                OptionPageGrid page = (OptionPageGrid)GetDialogPage(typeof(OptionPageGrid));
+                return page.ScanOnSave;
+            }
+        }
+
+        #region Package Members
+
+        #endregion
+    }
+}

--- a/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio/OptionPageGrid.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio/OptionPageGrid.cs
@@ -1,0 +1,32 @@
+﻿namespace Microsoft.DevSkim.VisualStudio
+{
+    using Microsoft.VisualStudio.Shell;
+    using System.ComponentModel;
+
+    public class OptionPageGrid : DialogPage
+    {
+        [Category("Scan Options")]
+        [DisplayName("Scan On Save")]
+        [Description("Scan When Document Is Saved")]
+        public bool ScanOnSave
+        {
+            get; set;
+        } = true;
+        [Category("Scan Options")]
+        [DisplayName("Scan On Change")]
+        [Description("Scan When Document Is Changed")]
+        public bool ScanOnChange
+        {
+            get; set;
+        } = true;
+        [Category("Scan Options")]
+        [DisplayName("Scan On Open")]
+        [Description("Scan When Document Is Opened")]
+        public bool ScanOnOpen
+        {
+            get; set;
+        } = true;
+
+
+    }
+}

--- a/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio/Properties/AssemblyInfo.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio/Properties/AssemblyInfo.cs
@@ -1,0 +1,31 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Microsoft.DevSkim.VisualStudio")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Microsoft.DevSkim.VisualStudio")]
+[assembly: AssemblyCopyright("")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]

--- a/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio/RuleOptionPageGrid.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio/RuleOptionPageGrid.cs
@@ -1,0 +1,17 @@
+﻿namespace Microsoft.DevSkim.VisualStudio
+{
+    using Microsoft.VisualStudio.Shell;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+
+    public class RuleOptionPageGrid : DialogPage
+    {
+        [Category("Rule Options")]
+        [DisplayName("Custom Rule Paths")]
+        [Description("Paths to load cutom rules from")]
+        public List<string> CustomRulePaths
+        {
+            get; set;
+        } = new List<string>();
+    }
+}

--- a/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio/source.extension.vsixmanifest
+++ b/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio/source.extension.vsixmanifest
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
+    <Metadata>
+        <Identity Id="Microsoft.DevSkim.VisualStudio.d1769410-aa48-48f6-b157-da14546b6c28" Version="1.0" Language="en-US" Publisher="Gabe Stocco" />
+        <DisplayName>Microsoft.DevSkim.VisualStudio</DisplayName>
+        <Description>Empty VSIX Project.</Description>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+      <Dependency Id="Microsoft.VisualStudio.MPF.16.0" DisplayName="Visual Studio MPF 16.0" d:Source="Installed" Version="[16.0,17.0)" />
+  </Dependencies>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+      <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+  </Assets>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,18.0)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
+</PackageManifest>

--- a/DevSkim-DotNet/Microsoft.DevSkim.sln
+++ b/DevSkim-DotNet/Microsoft.DevSkim.sln
@@ -1,73 +1,109 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29709.97
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33516.290
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DevSkim", "Microsoft.DevSkim\Microsoft.DevSkim.csproj", "{7B8D0088-645A-4D4B-9DB9-046EED07B47A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DevSkim", "Microsoft.DevSkim\Microsoft.DevSkim.csproj", "{7B8D0088-645A-4D4B-9DB9-046EED07B47A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DevSkim.CLI", "Microsoft.DevSkim.CLI\Microsoft.DevSkim.CLI.csproj", "{6330E8E3-8D91-458E-945C-CE9B71FE809B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DevSkim.CLI", "Microsoft.DevSkim.CLI\Microsoft.DevSkim.CLI.csproj", "{6330E8E3-8D91-458E-945C-CE9B71FE809B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DevSkim.Tests", "Microsoft.DevSkim.Tests\Microsoft.DevSkim.Tests.csproj", "{22E5C50D-93C9-4007-881F-D8B751B880D0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DevSkim.Tests", "Microsoft.DevSkim.Tests\Microsoft.DevSkim.Tests.csproj", "{22E5C50D-93C9-4007-881F-D8B751B880D0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DevSkim.LanguageServer", "Microsoft.DevSkim.LanguageServer\Microsoft.DevSkim.LanguageServer.csproj", "{1668F782-FE09-4106-8393-9A9D9823E027}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DevSkim.LanguageServer", "Microsoft.DevSkim.LanguageServer\Microsoft.DevSkim.LanguageServer.csproj", "{1668F782-FE09-4106-8393-9A9D9823E027}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DevSkim.VisualStudio", "Microsoft.DevSkim.VisualStudio\Microsoft.DevSkim.VisualStudio.csproj", "{E7A5F71D-137D-4D65-AB27-2ADD1FA6B26B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|arm64 = Debug|arm64
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|arm64 = Release|arm64
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{7B8D0088-645A-4D4B-9DB9-046EED07B47A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7B8D0088-645A-4D4B-9DB9-046EED07B47A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7B8D0088-645A-4D4B-9DB9-046EED07B47A}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{7B8D0088-645A-4D4B-9DB9-046EED07B47A}.Debug|arm64.Build.0 = Debug|Any CPU
 		{7B8D0088-645A-4D4B-9DB9-046EED07B47A}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{7B8D0088-645A-4D4B-9DB9-046EED07B47A}.Debug|x64.Build.0 = Debug|Any CPU
 		{7B8D0088-645A-4D4B-9DB9-046EED07B47A}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{7B8D0088-645A-4D4B-9DB9-046EED07B47A}.Debug|x86.Build.0 = Debug|Any CPU
 		{7B8D0088-645A-4D4B-9DB9-046EED07B47A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7B8D0088-645A-4D4B-9DB9-046EED07B47A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7B8D0088-645A-4D4B-9DB9-046EED07B47A}.Release|arm64.ActiveCfg = Release|Any CPU
+		{7B8D0088-645A-4D4B-9DB9-046EED07B47A}.Release|arm64.Build.0 = Release|Any CPU
 		{7B8D0088-645A-4D4B-9DB9-046EED07B47A}.Release|x64.ActiveCfg = Release|Any CPU
 		{7B8D0088-645A-4D4B-9DB9-046EED07B47A}.Release|x64.Build.0 = Release|Any CPU
 		{7B8D0088-645A-4D4B-9DB9-046EED07B47A}.Release|x86.ActiveCfg = Release|Any CPU
 		{7B8D0088-645A-4D4B-9DB9-046EED07B47A}.Release|x86.Build.0 = Release|Any CPU
 		{6330E8E3-8D91-458E-945C-CE9B71FE809B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6330E8E3-8D91-458E-945C-CE9B71FE809B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6330E8E3-8D91-458E-945C-CE9B71FE809B}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{6330E8E3-8D91-458E-945C-CE9B71FE809B}.Debug|arm64.Build.0 = Debug|Any CPU
 		{6330E8E3-8D91-458E-945C-CE9B71FE809B}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{6330E8E3-8D91-458E-945C-CE9B71FE809B}.Debug|x64.Build.0 = Debug|Any CPU
 		{6330E8E3-8D91-458E-945C-CE9B71FE809B}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{6330E8E3-8D91-458E-945C-CE9B71FE809B}.Debug|x86.Build.0 = Debug|Any CPU
 		{6330E8E3-8D91-458E-945C-CE9B71FE809B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6330E8E3-8D91-458E-945C-CE9B71FE809B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6330E8E3-8D91-458E-945C-CE9B71FE809B}.Release|arm64.ActiveCfg = Release|Any CPU
+		{6330E8E3-8D91-458E-945C-CE9B71FE809B}.Release|arm64.Build.0 = Release|Any CPU
 		{6330E8E3-8D91-458E-945C-CE9B71FE809B}.Release|x64.ActiveCfg = Release|Any CPU
 		{6330E8E3-8D91-458E-945C-CE9B71FE809B}.Release|x64.Build.0 = Release|Any CPU
 		{6330E8E3-8D91-458E-945C-CE9B71FE809B}.Release|x86.ActiveCfg = Release|Any CPU
 		{6330E8E3-8D91-458E-945C-CE9B71FE809B}.Release|x86.Build.0 = Release|Any CPU
 		{22E5C50D-93C9-4007-881F-D8B751B880D0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{22E5C50D-93C9-4007-881F-D8B751B880D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22E5C50D-93C9-4007-881F-D8B751B880D0}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{22E5C50D-93C9-4007-881F-D8B751B880D0}.Debug|arm64.Build.0 = Debug|Any CPU
 		{22E5C50D-93C9-4007-881F-D8B751B880D0}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{22E5C50D-93C9-4007-881F-D8B751B880D0}.Debug|x64.Build.0 = Debug|Any CPU
 		{22E5C50D-93C9-4007-881F-D8B751B880D0}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{22E5C50D-93C9-4007-881F-D8B751B880D0}.Debug|x86.Build.0 = Debug|Any CPU
 		{22E5C50D-93C9-4007-881F-D8B751B880D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{22E5C50D-93C9-4007-881F-D8B751B880D0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{22E5C50D-93C9-4007-881F-D8B751B880D0}.Release|arm64.ActiveCfg = Release|Any CPU
+		{22E5C50D-93C9-4007-881F-D8B751B880D0}.Release|arm64.Build.0 = Release|Any CPU
 		{22E5C50D-93C9-4007-881F-D8B751B880D0}.Release|x64.ActiveCfg = Release|Any CPU
 		{22E5C50D-93C9-4007-881F-D8B751B880D0}.Release|x64.Build.0 = Release|Any CPU
 		{22E5C50D-93C9-4007-881F-D8B751B880D0}.Release|x86.ActiveCfg = Release|Any CPU
 		{22E5C50D-93C9-4007-881F-D8B751B880D0}.Release|x86.Build.0 = Release|Any CPU
 		{1668F782-FE09-4106-8393-9A9D9823E027}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1668F782-FE09-4106-8393-9A9D9823E027}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1668F782-FE09-4106-8393-9A9D9823E027}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{1668F782-FE09-4106-8393-9A9D9823E027}.Debug|arm64.Build.0 = Debug|Any CPU
 		{1668F782-FE09-4106-8393-9A9D9823E027}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{1668F782-FE09-4106-8393-9A9D9823E027}.Debug|x64.Build.0 = Debug|Any CPU
 		{1668F782-FE09-4106-8393-9A9D9823E027}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{1668F782-FE09-4106-8393-9A9D9823E027}.Debug|x86.Build.0 = Debug|Any CPU
 		{1668F782-FE09-4106-8393-9A9D9823E027}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1668F782-FE09-4106-8393-9A9D9823E027}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1668F782-FE09-4106-8393-9A9D9823E027}.Release|arm64.ActiveCfg = Release|Any CPU
+		{1668F782-FE09-4106-8393-9A9D9823E027}.Release|arm64.Build.0 = Release|Any CPU
 		{1668F782-FE09-4106-8393-9A9D9823E027}.Release|x64.ActiveCfg = Release|Any CPU
 		{1668F782-FE09-4106-8393-9A9D9823E027}.Release|x64.Build.0 = Release|Any CPU
 		{1668F782-FE09-4106-8393-9A9D9823E027}.Release|x86.ActiveCfg = Release|Any CPU
 		{1668F782-FE09-4106-8393-9A9D9823E027}.Release|x86.Build.0 = Release|Any CPU
+		{E7A5F71D-137D-4D65-AB27-2ADD1FA6B26B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E7A5F71D-137D-4D65-AB27-2ADD1FA6B26B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E7A5F71D-137D-4D65-AB27-2ADD1FA6B26B}.Debug|arm64.ActiveCfg = Debug|arm64
+		{E7A5F71D-137D-4D65-AB27-2ADD1FA6B26B}.Debug|arm64.Build.0 = Debug|arm64
+		{E7A5F71D-137D-4D65-AB27-2ADD1FA6B26B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E7A5F71D-137D-4D65-AB27-2ADD1FA6B26B}.Debug|x64.Build.0 = Debug|Any CPU
+		{E7A5F71D-137D-4D65-AB27-2ADD1FA6B26B}.Debug|x86.ActiveCfg = Debug|x86
+		{E7A5F71D-137D-4D65-AB27-2ADD1FA6B26B}.Debug|x86.Build.0 = Debug|x86
+		{E7A5F71D-137D-4D65-AB27-2ADD1FA6B26B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E7A5F71D-137D-4D65-AB27-2ADD1FA6B26B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E7A5F71D-137D-4D65-AB27-2ADD1FA6B26B}.Release|arm64.ActiveCfg = Release|arm64
+		{E7A5F71D-137D-4D65-AB27-2ADD1FA6B26B}.Release|arm64.Build.0 = Release|arm64
+		{E7A5F71D-137D-4D65-AB27-2ADD1FA6B26B}.Release|x64.ActiveCfg = Release|Any CPU
+		{E7A5F71D-137D-4D65-AB27-2ADD1FA6B26B}.Release|x64.Build.0 = Release|Any CPU
+		{E7A5F71D-137D-4D65-AB27-2ADD1FA6B26B}.Release|x86.ActiveCfg = Release|x86
+		{E7A5F71D-137D-4D65-AB27-2ADD1FA6B26B}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Basic Diagnostics reporting is working and there's a few settings implemented to be displayed.

Todo:
The VS Language client needs to respond properly to the configuration request. TBD how to format that, if we need different formats for vs code and vs mode.
Settings pane needs to be filled out, and match VS Code settings pane.
Lightbulb fixes are not implemented. Need to listen for the code fix action notification like on vscode extension and stash them, then add a suggested action provider, see either samples or devskim 0.7 extension.