### PR TITLE
Fix Git Tags for Extensions

### DIFF
--- a/Pipelines/vs/devskim-visualstudio-release.yml
+++ b/Pipelines/vs/devskim-visualstudio-release.yml
@@ -179,7 +179,7 @@ stages:
         action: 'create'
         target: '$(Build.SourceVersion)'
         tagSource: 'userSpecifiedTag'
-        tag: 'VS v$(ReleaseVersion)'
+        tag: 'VS_v$(ReleaseVersion)'
         title: 'DevSkim VS Extension v$(ReleaseVersion)'
         assets: |
           $(Build.StagingDirectory)/*.vsix

--- a/Pipelines/vscode/devskim-vscode-release.yml
+++ b/Pipelines/vscode/devskim-vscode-release.yml
@@ -233,7 +233,7 @@ stages:
         action: 'create'
         target: '$(Build.SourceVersion)'
         tagSource: 'userSpecifiedTag'
-        tag: 'VSCode v$(ReleaseVersion)'
+        tag: 'VSCode_v$(ReleaseVersion)'
         title: 'DevSkim VS Code Extension v$(ReleaseVersion)'
         assets: |
           $(Build.StagingDirectory)/*.vsix


### PR DESCRIPTION
Replaces tag string spaces with underscores; an obvious requirement that I did not consider.