### PR TITLE
Fixes #116

### DIFF
--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/AnalyzeCommand.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/AnalyzeCommand.cs
@@ -65,8 +65,8 @@ namespace Microsoft.DevSkim.CLI.Commands
                                     var maybeOptionAttribute = prop.GetCustomAttributes(true)?.Where(x => x is OptionAttribute).FirstOrDefault();
                                     if (maybeOptionAttribute is OptionAttribute optionAttribute)
                                     {
-                                        // Check if hte option attributes default value differs from the value in the CLI provided options
-                                        // If the CLI provided a non-default option, override the deserialized option
+                                        // Check if the option attributes default value differs from the value in the CLI provided options
+                                        //   If the CLI provided a non-default option, override the deserialized option
                                         if (!optionAttribute.Default.Equals(value))
                                         {
                                             var selectedProp =

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/AnalyzeCommand.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/AnalyzeCommand.cs
@@ -84,6 +84,7 @@ namespace Microsoft.DevSkim.CLI.Commands
                         catch (Exception e)
                         {
                             Debug.WriteLine("Error while parsing additional options {0}", e.Message);
+                            return (int)ExitCode.CriticalError;
                         }
                     }
                 }

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/AnalyzeCommand.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/AnalyzeCommand.cs
@@ -48,7 +48,6 @@ namespace Microsoft.DevSkim.CLI.Commands
                 // Check if the options json is specified.
                 if (!string.IsNullOrEmpty(optsWithJson.PathToOptionsJson))
                 {
-                
                     if (File.Exists(optsWithJson.PathToOptionsJson))
                     {
                         try
@@ -57,13 +56,17 @@ namespace Microsoft.DevSkim.CLI.Commands
                                 JsonSerializer.Deserialize<SerializedAnalyzeCommandOptions>(File.ReadAllText(optsWithJson.PathToOptionsJson));
                             if (deserializedOptions is { })
                             {
+                                // For each property in the opts argument, if the argument is not default, override the equivalent from the deserialized options
                                 var serializedProperties = typeof(SerializedAnalyzeCommandOptions).GetProperties();
-                                foreach (var prop in typeof(BaseAnalyzeCommandOptions).GetProperties().Where(x => x.Name != "PathToOptionsJson"))
+                                foreach (var prop in typeof(BaseAnalyzeCommandOptions).GetProperties())
                                 {
                                     var value = prop.GetValue(opts);
+                                    // Get the option attribute from the property
                                     var maybeOptionAttribute = prop.GetCustomAttributes(true)?.Where(x => x is OptionAttribute).FirstOrDefault();
                                     if (maybeOptionAttribute is OptionAttribute optionAttribute)
                                     {
+                                        // Check if hte option attributes default value differs from the value in the CLI provided options
+                                        // If the CLI provided a non-default option, override the deserialized option
                                         if (!optionAttribute.Default.Equals(value))
                                         {
                                             var selectedProp =
@@ -72,7 +75,8 @@ namespace Microsoft.DevSkim.CLI.Commands
                                         }
                                     }
                                 }
-
+                                
+                                // Replace the regular options with the deserialized options
                                 opts = deserializedOptions;
                             }
                             

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/AnalyzeCommandOptions.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/AnalyzeCommandOptions.cs
@@ -1,82 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
 using CommandLine;
-using Microsoft.ApplicationInspector.RulesEngine;
-using Microsoft.DevSkim.CLI.Writers;
 
 namespace Microsoft.DevSkim.CLI.Options;
 
 [Verb("analyze", HelpText = "Analyze source code using DevSkim")]
-public class AnalyzeCommandOptions
+public record AnalyzeCommandOptions : BaseAnalyzeCommandOptions
 {
-    [Option('r', HelpText = "Comma separated list of paths to rules files to use", Separator = ',')]
-    public IEnumerable<string> Rules { get; set; } = Array.Empty<string>();
-    
-    [Option("rule-ids", HelpText = "Comma separated list of rule IDs to limit analysis to", Separator = ',')]
-    public IEnumerable<string> RuleIds { get; set; } = Array.Empty<string>();
-    
-    [Option("ignore-rule-ids", HelpText = "Comma separated list of rule IDs to ignore", Separator = ',')]
-    public IEnumerable<string> IgnoreRuleIds { get; set; } = Array.Empty<string>();
-
-    [Option("languages",Required = false, HelpText = "Path to custom json formatted Language file to specify languages, when specified comments must also be specified")]
-    public string LanguagesPath { get; set; } = string.Empty;
-    
-    [Option("comments",Required = false, HelpText = "Path to custom json formatted Comments file to specify languages, when specified languages must also be specified")]
-    public string CommentsPath { get; set; } = string.Empty;
-
-    [Option('I', "source-code",Required = true, HelpText = "Path to a directory containing files to scan or a single file to scan")]
-    public string Path { get; set; } = string.Empty;
-    
-    [Option('O',"output-file",Required = false, HelpText = "Filename for result file, uses stdout if not set.")]
-    public string OutputFile { get; set; } = string.Empty;
-    
-    [Option('o', "output-format", HelpText = "Format for output text.", Default = SimpleTextWriter.DefaultFormat)]
-    public string OutputTextFormat { get; set; } = string.Empty;
-    
-    [Option('f',"file-format", HelpText = "Format type for output. [text|sarif]", Default = "sarif")]
-    public string OutputFileFormat { get; set; } = string.Empty;
-    
-    [Option('s',"severity", HelpText = "Comma-separated Severities to match", Separator = ',', Default = new[]{Severity.Critical, Severity.Important, Severity.Moderate, Severity.BestPractice, Severity.ManualReview })]
-    public IEnumerable<Severity> Severities { get; set; } = new[]{Severity.Critical, Severity.Important, Severity.Moderate, Severity.BestPractice, Severity.ManualReview };
-    
-    [Option("confidence", HelpText = "Comma-separated Severities to match", Separator = ',', Default = new[]{ Confidence.High, Confidence.Medium })]
-    public IEnumerable<Confidence> Confidences { get; set; } = new[]{ Confidence.High, Confidence.Medium };
-    
-    [Option('g',"ignore-globs", HelpText = "Comma-separated Globs for files to skip analyzing", Separator = ',', Default = new []{"**/.git/**","**/bin/**"})]
-    public IEnumerable<string> Globs { get; set; }  = Array.Empty<string>();
-    
-    [Option('d',"disable-supression", HelpText = "Disable comment suppressions")]
-    public bool DisableSuppression { get; set; }
-    
-    [Option("disable-parallel", HelpText = "Disable parallel processing")]
-    public bool DisableParallel { get; set; }
-    
-    [Option('i',"ignore-default-rules", HelpText = "Ignore default rules")]
-    public bool IgnoreDefaultRules { get; set; }
-    
-    [Option("suppress-standard-error", HelpText = "Suppress output to std err")]
-    public bool SuppressStdErr { get; set; }
-    
-    [Option('c',"crawl-archives", HelpText = "Analyze files contained inside of archives")]
-    public bool CrawlArchives { get; set; }
-    
-    [Option('E', HelpText = "Use exit code for number of issues. Negative on error.")]
-    public bool ExitCodeIsNumIssues { get; set; }
-    
-    [Option("base-path",
-        HelpText =
-            "Specify what path to root result URIs in Sarif results with. When not set will generate paths relative to the source directory (or directory containing the source file specified)")]
-    public string BasePath { get; set; } = string.Empty;
-    
-    [Option("absolute-path", HelpText = "Output absolute paths (overrides --base-path).")]
-    public bool AbsolutePaths { get; set; }
-    
-    [Option("suppress-error", HelpText = "Don't output to stderr")]
-    public bool SuppressError { get; set; }
-    
-    [Option("skip-git-ignored-files", HelpText = "Set to skip files which are ignored by .gitignore. Requires git to be installed.")]
-    public bool RespectGitIgnore { get; set; }
-    
-    [Option("skip-excerpts", HelpText = "Set to skip gathering excerpts and samples to include in the report.")]
-    public bool SkipExcerpts { get; set; }
+    [Option("options-json", 
+        HelpText = "The path to a .json file that contains a serialized SerializedAnalyzeCommandOptions object which can specify both Analyze options and extra options. Options specified explicitly override options from this argument.", Default = "")]
+    public string PathToOptionsJson { get; set; } = String.Empty;
 }

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/BaseAnalyzeCommandOptions.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/BaseAnalyzeCommandOptions.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using CommandLine;
+using Microsoft.ApplicationInspector.RulesEngine;
+using Microsoft.DevSkim.CLI.Writers;
+
+namespace Microsoft.DevSkim.CLI.Options;
+
+public record BaseAnalyzeCommandOptions
+{
+    [Option('r', HelpText = "Comma separated list of paths to rules files to use", Separator = ',', Default = new string[]{})]
+    public IEnumerable<string> Rules { get; set; } = Array.Empty<string>();
+    
+    [Option("rule-ids", HelpText = "Comma separated list of rule IDs to limit analysis to", Separator = ',', Default = new string[]{})]
+    public IEnumerable<string> RuleIds { get; set; } = Array.Empty<string>();
+    
+    [Option("ignore-rule-ids", HelpText = "Comma separated list of rule IDs to ignore", Separator = ',', Default = new string[]{})]
+    public IEnumerable<string> IgnoreRuleIds { get; set; } = Array.Empty<string>();
+
+    [Option("languages", HelpText = "Path to custom json formatted Language file to specify languages, when specified comments must also be specified", Default = "")]
+    public string LanguagesPath { get; set; } = string.Empty;
+    
+    [Option("comments",Required = false, HelpText = "Path to custom json formatted Comments file to specify languages, when specified languages must also be specified", Default = "")]
+    public string CommentsPath { get; set; } = string.Empty;
+
+    [Option('I', "source-code",Required = true, HelpText = "Path to a directory containing files to scan or a single file to scan", Default = "")]
+    public string Path { get; set; } = string.Empty;
+    
+    [Option('O',"output-file",Required = false, HelpText = "Filename for result file, uses stdout if not set.", Default = "")]
+    public string OutputFile { get; set; } = string.Empty;
+    
+    [Option('o', "output-format", HelpText = "Format for output text.", Default = SimpleTextWriter.DefaultFormat)]
+    public string OutputTextFormat { get; set; } = string.Empty;
+    
+    [Option('f',"file-format", HelpText = "Format type for output. [text|sarif]", Default = "sarif")]
+    public string OutputFileFormat { get; set; } = string.Empty;
+    
+    [Option('s',"severity", HelpText = "Comma-separated Severities to match", Separator = ',', Default = new[]{Severity.Critical, Severity.Important, Severity.Moderate, Severity.BestPractice, Severity.ManualReview })]
+    public IEnumerable<Severity> Severities { get; set; } = new[]{Severity.Critical, Severity.Important, Severity.Moderate, Severity.BestPractice, Severity.ManualReview };
+    
+    [Option("confidence", HelpText = "Comma-separated Severities to match", Separator = ',', Default = new[]{ Confidence.High, Confidence.Medium })]
+    public IEnumerable<Confidence> Confidences { get; set; } = new[]{ Confidence.High, Confidence.Medium };
+    
+    [Option('g',"ignore-globs", HelpText = "Comma-separated Globs for files to skip analyzing", Separator = ',', Default = new []{"**/.git/**","**/bin/**"})]
+    public IEnumerable<string> Globs { get; set; }  = new []{"**/.git/**","**/bin/**"};
+    
+    [Option('d',"disable-supression", HelpText = "Disable comment suppressions", Default = false)]
+    public bool DisableSuppression { get; set; }
+    
+    [Option("disable-parallel", HelpText = "Disable parallel processing", Default = false)]
+    public bool DisableParallel { get; set; }
+    
+    [Option('i',"ignore-default-rules", HelpText = "Ignore default rules", Default = false)]
+    public bool IgnoreDefaultRules { get; set; }
+    
+    [Option('c',"crawl-archives", HelpText = "Analyze files contained inside of archives", Default = false)]
+    public bool CrawlArchives { get; set; }
+    
+    [Option('E', HelpText = "Use exit code for number of issues. Negative on error.", Default = false)]
+    public bool ExitCodeIsNumIssues { get; set; }
+    
+    [Option("base-path",
+        HelpText =
+            "Specify what path to root result URIs in Sarif results with. When not set will generate paths relative to the source directory (or directory containing the source file specified)", Default = "")]
+    public string BasePath { get; set; } = string.Empty;
+    
+    [Option("absolute-path", HelpText = "Output absolute paths (overrides --base-path).", Default = false)]
+    public bool AbsolutePaths { get; set; }
+    
+    [Option("suppress-error", HelpText = "Don't output to stderr", Default = false)]
+    public bool SuppressError { get; set; }
+    
+    [Option("skip-git-ignored-files", HelpText = "Set to skip files which are ignored by .gitignore. Requires git to be installed.", Default = false)]
+    public bool RespectGitIgnore { get; set; }
+    
+    [Option("skip-excerpts", HelpText = "Set to skip gathering excerpts and samples to include in the report.", Default = false)]
+    public bool SkipExcerpts { get; set; }
+}

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/FixCommandOptions.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/FixCommandOptions.cs
@@ -5,7 +5,7 @@ using CommandLine;
 namespace Microsoft.DevSkim.CLI.Options;
 
 [Verb("fix", HelpText = "Apply fixes from a Sarif")]
-public class FixCommandOptions
+public record FixCommandOptions
 {
     [Option('I', "source-code", Required = true, HelpText = "Path to the parent directory containing the source code that was scanned to produce the sarif.")]
     public string Path { get; set; } = String.Empty;

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/SerializedAnalyzeCommandOptions.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/SerializedAnalyzeCommandOptions.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace Microsoft.DevSkim.CLI.Options;
+
+/// <summary>
+/// A serializable options object to provide to the analyze command.
+/// </summary>
+public record SerializedAnalyzeCommandOptions : BaseAnalyzeCommandOptions
+{
+    /// <summary>
+    /// Dictionary that maps Language name to RuleIDs to ignore
+    /// </summary>
+    public IDictionary<string, List<string>> LanguageRuleIgnoreMap { get; set; } =
+        new Dictionary<string, List<string>>();
+}

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/SuppressionCommandOptions.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/SuppressionCommandOptions.cs
@@ -5,7 +5,7 @@ using CommandLine;
 namespace Microsoft.DevSkim.CLI.Options;
 
 [Verb("suppress", HelpText = "Suppress issues identified in a DevSkim Sarif")]
-public class SuppressionCommandOptions
+public record SuppressionCommandOptions
 {
     [Option('I', "source-code", Required = true, HelpText = "Path to the parent directory containing the source code that was scanned to produce the sarif.")]
     public string Path { get; set; } = String.Empty;

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/VerifyCommandOptions.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/VerifyCommandOptions.cs
@@ -5,7 +5,7 @@ using CommandLine;
 namespace Microsoft.DevSkim.CLI.Options;
 
 [Verb("verify", HelpText = "Verify rule validity")]
-public class VerifyCommandOptions
+public record VerifyCommandOptions
 {
     [Option('r', HelpText = "Comma separated list of paths to rules files to use", Separator = ',')]
     public IEnumerable<string> Rules { get; set; } = Array.Empty<string>();


### PR DESCRIPTION
Adds a way to configure disabling rules on a per language basis to the analyze command, and to specify non-required options using json.