### PR TITLE
Use base 2.1.0 schema

### DIFF
--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
@@ -102,9 +102,11 @@ namespace Microsoft.DevSkim.CLI.Writers
                 rule["level"] = "warning";
             }
             
+            // Begin Workaround for https://github.com/microsoft/sarif-sdk/issues/2662
+            reReadLog["$schema"] = "https://www.schemastore.org/schemas/json/sarif-2.1.0.json";
             using var jsonWriter = new JsonTextWriter(TextWriter);
             reReadLog.WriteTo(jsonWriter);
-            // End Workaround
+            // End Workarounds
 
             TextWriter.Flush();
         }

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
@@ -103,6 +103,7 @@ namespace Microsoft.DevSkim.CLI.Writers
             }
             
             // Begin Workaround for https://github.com/microsoft/sarif-sdk/issues/2662
+            // The default provided schema is 404, so replace it with a 2.1.0 that is available.
             reReadLog["$schema"] = "https://www.schemastore.org/schemas/json/sarif-2.1.0.json";
             using var jsonWriter = new JsonTextWriter(TextWriter);
             reReadLog.WriteTo(jsonWriter);


### PR DESCRIPTION
The default url provided is a 404. Workaround for https://github.com/microsoft/sarif-sdk/issues/2662