### PR TITLE
Add case insensitive modifier to Hash algorithm detections

### DIFF
--- a/rules/default/security/cryptography/hash_algorithm.json
+++ b/rules/default/security/cryptography/hash_algorithm.json
@@ -15,7 +15,8 @@
                 "type": "regex",
                 "scopes": [
                     "code"
-                ]
+                ],
+                "modifiers":["i"]
             }
         ],
         "fix_its": [
@@ -29,7 +30,6 @@
                     "scopes": [
                         "code"
                     ],
-                    "modifiers":["i"],
                     "_comment": ""
                 }
             },
@@ -44,7 +44,9 @@
                         "code"
                     ],
                     "_comment": ""
-                },
+                }
+            },
+            {
                 "name": "Change to \"sha512\"",
                 "type": "RegexReplace",
                 "replacement": "sha512",
@@ -55,7 +57,20 @@
                         "code"
                     ],
                     "_comment": "Matches lower case variants of the above"
-                },
+                }
+            },
+            {
+                "name": "Change to \"sha256\"",
+                "type": "RegexReplace",
+                "replacement": "sha256",
+                "pattern": {
+                    "pattern": "(md2|md4|md5|ripemd|ripemd(128|256|160|320)|(sha0|sha-0|sha1|sha-1))",
+                    "type": "regex",
+                    "scopes": [
+                        "code"
+                    ],
+                    "_comment": "Matches lower case variants of the above"
+                }
             }
         ],
         "must-match": [

--- a/rules/default/security/cryptography/hash_algorithm.json
+++ b/rules/default/security/cryptography/hash_algorithm.json
@@ -29,6 +29,7 @@
                     "scopes": [
                         "code"
                     ],
+                    "modifiers":["i"],
                     "_comment": ""
                 }
             },
@@ -43,11 +44,23 @@
                         "code"
                     ],
                     "_comment": ""
-                }
+                },
+                "name": "Change to \"sha512\"",
+                "type": "RegexReplace",
+                "replacement": "sha512",
+                "pattern": {
+                    "pattern": "(md2|md4|md5|ripemd|ripemd(128|256|160|320)|(sha0|sha-0|sha1|sha-1))",
+                    "type": "regex",
+                    "scopes": [
+                        "code"
+                    ],
+                    "_comment": "Matches lower case variants of the above"
+                },
             }
         ],
         "must-match": [
-            "MD5 hash = new Hash();"
+            "MD5 hash = new Hash();",
+            "echo -n Welcome | md5sum"
         ],
         "must-not-match": [
             "SHA512"


### PR DESCRIPTION
For some languages, like shell scripts, MD5 is called with lowercase `md5`, this adds the case insensitive flag to the rule and a must match example for shellscript's `md5sum` to validate it.