### PR TITLE
Try fix missing Help.Text parameter when Recommendation and Descripti…

### DIFF
--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
@@ -202,7 +202,7 @@ namespace Microsoft.DevSkim.CLI.Writers
                 sarifRule.FullDescription = new MultiformatMessageString() { Text = devskimRule.Description };
                 sarifRule.Help = new MultiformatMessageString()
                 {
-                    Text = devskimRule.Recommendation ?? devskimRule.Description,
+                    Text = devskimRule.Recommendation ?? devskimRule.Description ?? $"Visit {helpUri} for guidance on this issue.",
                     Markdown = $"Visit [{helpUri}]({helpUri}) for guidance on this issue."
                 };
                 sarifRule.HelpUri = helpUri;


### PR DESCRIPTION
…on are both empty.

GitHub's sarif upload task requires the Help.Text property of each Rule to be populated with a string. In cases where both Description and Recommendation were missing this property would have been null and thus invalid by the upload tasks' requirements. This PR adds a backup string that won't be null in the case that both of the previous properties are null.