### PR TITLE
Filter potentially duplicate fixes in sarif output

### DIFF
--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using Microsoft.ApplicationInspector.RulesEngine;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -198,9 +199,9 @@ namespace Microsoft.DevSkim.CLI.Writers
                 Uri helpUri = new Uri("https://github.com/Microsoft/DevSkim/blob/main/guidance/" + devskimRule.RuleInfo); ;
                 ReportingDescriptor sarifRule = new ReportingDescriptor();
                 sarifRule.Id = devskimRule.Id;
-                sarifRule.Name = devskimRule.Name;
+                sarifRule.Name = ToSarifFriendlyName(devskimRule.Name);
                 sarifRule.ShortDescription = new MultiformatMessageString() { Text = devskimRule.Description };
-                sarifRule.FullDescription = new MultiformatMessageString() { Text = devskimRule.Description };
+                sarifRule.FullDescription = new MultiformatMessageString() { Text = $"{devskimRule.Name}: {devskimRule.Description}" };
                 sarifRule.Help = new MultiformatMessageString()
                 {
                     // If recommendation is present use that, otherwise use description if present, otherwise use the HelpUri
@@ -220,6 +221,12 @@ namespace Microsoft.DevSkim.CLI.Writers
                 _rules.TryAdd(devskimRule.Id, sarifRule);
             }
         }
+
+        private string ToSarifFriendlyName(string devskimRuleName) =>
+            string.Concat(devskimRuleName.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                .Select(x => string.Concat(x.Where(char.IsLetterOrDigit)))
+                .Select(word => string.IsNullOrEmpty(word) ? string.Empty : 
+                    word.Length == 1 ? word : $"{word[..1].ToUpper()}{word[1..].ToLower()}"));
 
         /// <summary>
         /// Gets deduplicated set of fixes for the issue

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
@@ -225,7 +225,7 @@ namespace Microsoft.DevSkim.CLI.Writers
             List<Fix> fixes = new List<Fix>();
             if (issue.Issue.Rule.Fixes != null)
             {
-                foreach (CodeFix fix in issue.Issue.Rule.Fixes)
+                foreach (CodeFix fix in issue.Issue.Rule.Fixes.Where(codeFix => DevSkimRuleProcessor.IsFixable(issue.TextSample, codeFix)))
                 {
                     List<Replacement> replacements = new List<Replacement>();
                     replacements.Add(new Replacement(new Region()

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
@@ -32,7 +32,8 @@ namespace Microsoft.DevSkim.CLI.Writers
                 {
                     Driver = new ToolComponent()
                     {
-                        Rules = _rules.Select(x => x.Value).ToList()
+                        Rules = _rules.Select(x => x.Value).ToList(),
+                        InformationUri = new Uri("https://github.com/microsoft/DevSkim/")
                     }
                 },
                 Results = _results.ToList()

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
@@ -220,9 +220,14 @@ namespace Microsoft.DevSkim.CLI.Writers
             }
         }
 
+        /// <summary>
+        /// Gets deduplicated set of fixes for the issue
+        /// </summary>
+        /// <param name="issue"></param>
+        /// <returns></returns>
         private List<Fix> GetFixits(IssueRecord issue)
         {
-            List<Fix> fixes = new List<Fix>();
+            HashSet<Fix> fixes = new HashSet<Fix>();
             if (issue.Issue.Rule.Fixes != null)
             {
                 foreach (CodeFix fix in issue.Issue.Rule.Fixes.Where(codeFix => DevSkimRuleProcessor.IsFixable(issue.TextSample, codeFix)))
@@ -249,7 +254,7 @@ namespace Microsoft.DevSkim.CLI.Writers
                     });
                 }
             }
-            return fixes;
+            return fixes.ToList();
         }
 
         private void MapRuleToResult(Rule rule, ref Result resultItem)


### PR DESCRIPTION
Perform the Fix applies check before returning fixes in the sarif - required for different cases fixes for the hash algorithm rule.