### PR TITLE
Fix #546

### DIFF
--- a/rules/default/security/cryptography/hash_algorithm.json
+++ b/rules/default/security/cryptography/hash_algorithm.json
@@ -7,6 +7,7 @@
         "tags": [
             "Cryptography.BannedHashAlgorithm"
         ],
+        "does_not_apply_to": ["json"],
         "severity": "critical",
         "rule_info": "DS126858.md",
         "patterns": [


### PR DESCRIPTION
There is no "does_not_apply_to_file_regex" field currently, so the best we can do is exempt all json from this rule.