### PR TITLE
Fix NuGet Package Multitarget

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.7] - 2023-06-06
+### Fixed
+- Fixes issue where the CLI global tool package was attempting to run with a mismatched runtime.
+
 ## [1.0.6] - 2023-05-25
 ### Republish
 - Republish of 1.0.5 due to a release pipeline error

--- a/Pipelines/cli/devskim-cli-pr.yml
+++ b/Pipelines/cli/devskim-cli-pr.yml
@@ -13,7 +13,7 @@ resources:
     - repository: templates
       type: git
       name: SecurityEngineering/OSS-Tools-Pipeline-Templates
-      ref: refs/tags/v1.0.6
+      ref: refs/tags/v1.0.7
 
 stages:
 - stage: Test

--- a/Pipelines/cli/devskim-cli-release.yml
+++ b/Pipelines/cli/devskim-cli-release.yml
@@ -17,7 +17,7 @@ resources:
     - repository: templates
       type: git
       name: SecurityEngineering/OSS-Tools-Pipeline-Templates
-      ref: refs/tags/v1.0.6
+      ref: refs/tags/v1.0.7
 
 stages:
 - stage: Test

--- a/Pipelines/vs/devskim-visualstudio-pr.yml
+++ b/Pipelines/vs/devskim-visualstudio-pr.yml
@@ -13,7 +13,7 @@ resources:
     - repository: templates
       type: git
       name: SecurityEngineering/OSS-Tools-Pipeline-Templates
-      ref: refs/tags/v1.0.6
+      ref: refs/tags/v1.0.7
 
 stages:
 - stage: SDL

--- a/Pipelines/vs/devskim-visualstudio-release.yml
+++ b/Pipelines/vs/devskim-visualstudio-release.yml
@@ -17,7 +17,7 @@ resources:
     - repository: templates
       type: git
       name: SecurityEngineering/OSS-Tools-Pipeline-Templates
-      ref: refs/tags/v1.0.6
+      ref: refs/tags/v1.0.7
 
 stages:
 - stage: SDL

--- a/Pipelines/vscode/devskim-vscode-pr.yml
+++ b/Pipelines/vscode/devskim-vscode-pr.yml
@@ -13,7 +13,7 @@ resources:
     - repository: templates
       type: git
       name: SecurityEngineering/OSS-Tools-Pipeline-Templates
-      ref: refs/tags/v1.0.6
+      ref: refs/tags/v1.0.7
 
 stages:
 - stage: SDL

--- a/Pipelines/vscode/devskim-vscode-release.yml
+++ b/Pipelines/vscode/devskim-vscode-release.yml
@@ -17,7 +17,7 @@ resources:
     - repository: templates
       type: git
       name: SecurityEngineering/OSS-Tools-Pipeline-Templates
-      ref: refs/tags/v1.0.6
+      ref: refs/tags/v1.0.7
 
 stages:
 - stage: SDL


### PR DESCRIPTION
Fixes NuGet package issue where global tool will not always run with a matching runtime when the package is built from a project with multiple target frameworks.
