### PR TITLE
Improve suppress command handling of EOF and ignore messages

### DIFF
--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/SuppressionCommand.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/SuppressionCommand.cs
@@ -98,9 +98,12 @@ namespace Microsoft.DevSkim.CLI.Commands
                                     sb.Append($"{line}{Environment.NewLine}");
                                 }
 
+                                if (!theContent[zeroBasedStartLine].Contains(ignoreComment)) // if the target line already contains the ignore comment
+                                {
                                 string suppressionComment = isMultiline ? $"{ignoreComment}{theContent[zeroBasedStartLine]}{Environment.NewLine}" :
                                     $"{theContent[zeroBasedStartLine]} {ignoreComment}{Environment.NewLine}";
                                 sb.Append(suppressionComment);
+                            }
                             }
 
                             currLine = zeroBasedStartLine + 1;

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/SuppressionCommand.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/SuppressionCommand.cs
@@ -77,6 +77,8 @@ namespace Microsoft.DevSkim.CLI.Commands
                         _logger.LogError($"{potentialPath} specified in sarif does not appear to exist on disk.");
                     }
 
+                    var fileContent = File.ReadAllText(potentialPath);
+                    var fileEndsWithNewLine =  fileContent.EndsWith("\r\n") || fileContent.EndsWith("\n"); // OS agnostic newline check
                     string[] theContent = File.ReadAllLines(potentialPath);
                     int currLine = 0;
                     StringBuilder sb = new StringBuilder();
@@ -111,7 +113,9 @@ namespace Microsoft.DevSkim.CLI.Commands
                         {
                             sb.Append($"{line}{Environment.NewLine}");
                         }
-                        sb.Append($"{theContent.Last()}");
+                        var lastContentLine = theContent.Last();
+                        var lastLine = fileEndsWithNewLine ? $"{lastContentLine}{Environment.NewLine}" : lastContentLine;
+                        sb.Append(lastLine);
                     }
 
                     if (!_opts.DryRun)


### PR DESCRIPTION
- Keep empty line at EOF if the original file had one
- Only add a given suppression message if it is not already contained within the line