### PR TITLE
Remove scanWorkspace command from Extension

### DIFF
--- a/DevSkim-VSCode-Plugin/package.json
+++ b/DevSkim-VSCode-Plugin/package.json
@@ -72,13 +72,7 @@
 	],
 	"main": "./client/out/extension",
 	"contributes": {
-		"commands": [
-			{
-				"command": "MS-CST-E.vscode-devskim.scanWorkspace",
-				"category": "DevSkim",
-				"title": "Scan all files in the workspace"
-			}
-		],
+		"commands": [],
 		"configuration": [
 			{
 				"order": 10,


### PR DESCRIPTION
Fix issue #555

The `scanWorkspace` command was supposed to be remove during the bump to major version 1, but was missed.