### PR TITLE
Fix #554

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.9] - 2023-06-26
+### Fixed
+- Fixed an issue in the VS Code Extension that would try to run the language server with dotnet on the system path instead of the version fetched by the .NET Install Tool extension.
+
 ## [1.0.8] - 2023-06-09
 ### Rules
 - Adds new rules and improves precision of some existing rules.

--- a/DevSkim-VSCode-Plugin/client/extension.ts
+++ b/DevSkim-VSCode-Plugin/client/extension.ts
@@ -86,13 +86,13 @@ export function activate(context: ExtensionContext) {
 			const workPath = path.dirname(serverModule);
 			const serverOptions: ServerOptions = {
 				run: { 
-					command: "dotnet", 
+					command: dotNetPath, 
 					args: [serverModule], 
 					options: {cwd: workPath},
 					transport: TransportKind.pipe
 				},
 				debug: { 
-					command: "dotnet", 
+					command: dotNetPath, 
 					args: [serverModule], 
 					options: {cwd: workPath},
 					transport: TransportKind.pipe


### PR DESCRIPTION
Fixes an issue where we ensured that the .NET install tool had installed the proper version of .NET, but then we called the version of dotnet on the path to start the language server.