### PR TITLE
Remove workaround for missing Sarif Schema

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.20] - 2023-08-28
+### Fixes
+Removes workaround for 404 sarif schema uri
+
+### Dependencies
+Updates dependencies to latest.
+
 ## [1.0.19] - 2023-08-22
 ### VS Extension
 Fix concurrent access issue with cache storage for fixes. Fix #480

--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,9 @@ Removes workaround for 404 sarif schema uri
 ### Dependencies
 Updates dependencies to latest.
 
+### VS Extension
+Fix ordering of proposed fixes in UX. #582
+
 ## [1.0.19] - 2023-08-22
 ### VS Extension
 Fix concurrent access issue with cache storage for fixes. Fix #480

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Microsoft.DevSkim.CLI.csproj
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Microsoft.DevSkim.CLI.csproj
@@ -37,9 +37,9 @@
     <ItemGroup>
       <PackageReference Include="CommandLineParser" Version="2.9.1" />
       <PackageReference Include="LibGit2Sharp" Version="0.27.2" />
-      <PackageReference Include="Microsoft.CST.ApplicationInspector.Logging" Version="1.9.9" />
+      <PackageReference Include="Microsoft.CST.ApplicationInspector.Logging" Version="1.9.10" />
       <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
-      <PackageReference Include="Sarif.Sdk" Version="4.3.0" />
+      <PackageReference Include="Sarif.Sdk" Version="4.3.1" />
     </ItemGroup>
 
 </Project>

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
@@ -104,7 +104,7 @@ namespace Microsoft.DevSkim.CLI.Writers
                 rule["level"] = "warning";
             }
 
-            // Finally write out the fixed sarif
+            // Write out the fixed sarif
             using var jsonWriter = new JsonTextWriter(TextWriter);
             reReadLog.WriteTo(jsonWriter);
             // Add a newline at the end to make logging messages cleaner

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
@@ -104,9 +104,7 @@ namespace Microsoft.DevSkim.CLI.Writers
                 rule["level"] = "warning";
             }
 
-            // Begin Workaround for https://github.com/microsoft/sarif-sdk/issues/2662
-            // The default provided schema is 404, so replace it with a 2.1.0 that is available.
-            reReadLog["$schema"] = "https://www.schemastore.org/schemas/json/sarif-2.1.0.json";
+            // Finally write out the fixed sarif
             using var jsonWriter = new JsonTextWriter(TextWriter);
             reReadLog.WriteTo(jsonWriter);
             // Add a newline at the end to make logging messages cleaner

--- a/DevSkim-DotNet/Microsoft.DevSkim.LanguageServer/Microsoft.DevSkim.LanguageServer.csproj
+++ b/DevSkim-DotNet/Microsoft.DevSkim.LanguageServer/Microsoft.DevSkim.LanguageServer.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.CST.ApplicationInspector.RulesEngine" Version="1.9.9" />
+    <PackageReference Include="Microsoft.CST.ApplicationInspector.RulesEngine" Version="1.9.10" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.7" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />

--- a/DevSkim-DotNet/Microsoft.DevSkim.Tests/Microsoft.DevSkim.Tests.csproj
+++ b/DevSkim-DotNet/Microsoft.DevSkim.Tests/Microsoft.DevSkim.Tests.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
         <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
         <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     </ItemGroup>

--- a/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio.SourceGenerator/Microsoft.DevSkim.VisualStudio.SourceGenerator.csproj
+++ b/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio.SourceGenerator/Microsoft.DevSkim.VisualStudio.SourceGenerator.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.6.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.7.0" />
     </ItemGroup>
 
 </Project>

--- a/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio/Microsoft.DevSkim.VisualStudio.csproj
+++ b/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio/Microsoft.DevSkim.VisualStudio.csproj
@@ -87,12 +87,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Client">
-      <Version>17.7.20</Version>
+      <Version>17.6.42</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol">
       <Version>17.2.8</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.7.37357" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.6.36389" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.6.2164">

--- a/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio/Microsoft.DevSkim.VisualStudio.csproj
+++ b/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio/Microsoft.DevSkim.VisualStudio.csproj
@@ -87,12 +87,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Client">
-      <Version>17.6.42</Version>
+      <Version>17.7.20</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol">
       <Version>17.2.8</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.6.36389" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.7.37357" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.6.2164">

--- a/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio/Microsoft.DevSkim.VisualStudio.csproj
+++ b/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio/Microsoft.DevSkim.VisualStudio.csproj
@@ -85,14 +85,14 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Client">
-      <Version>17.6.42</Version>
+      <Version>17.7.20</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol">
       <Version>17.2.8</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.6.36389" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.7.37357" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.6.2164">

--- a/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio/SuggestionActionsSource.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio/SuggestionActionsSource.cs
@@ -50,7 +50,7 @@ namespace Microsoft.DevSkim.VisualStudio
                     {
                         suggestedActions.AddRange(fixes.Where(codeFixMapping => 
                             Intersects(codeFixMapping.Key, wordExtent))
-                            .OrderBy(fix => fix.Key)
+                            .OrderBy(fix => fix.Key.friendlyString)
                             .Select(intersectedMapping => new DevSkimSuggestedAction(wordExtent.Span, intersectedMapping.Key)));
                     }
                 }

--- a/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio/SuggestionActionsSource.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.VisualStudio/SuggestionActionsSource.cs
@@ -48,7 +48,10 @@ namespace Microsoft.DevSkim.VisualStudio
                 {
                     if (dictForFile.TryGetValue(wordExtent.Span.Snapshot.Version.VersionNumber, out ConcurrentDictionary<CodeFixMapping, bool> fixes))
                     {
-                        suggestedActions.AddRange(fixes.Where(codeFixMapping => Intersects(codeFixMapping.Key, wordExtent)).Select(intersectedMapping => new DevSkimSuggestedAction(wordExtent.Span, intersectedMapping.Key)));
+                        suggestedActions.AddRange(fixes.Where(codeFixMapping => 
+                            Intersects(codeFixMapping.Key, wordExtent))
+                            .OrderBy(fix => fix.Key)
+                            .Select(intersectedMapping => new DevSkimSuggestedAction(wordExtent.Span, intersectedMapping.Key)));
                     }
                 }
                 yield return new SuggestedActionSet(suggestedActions, wordExtent.Span);

--- a/DevSkim-DotNet/Microsoft.DevSkim/Microsoft.DevSkim.csproj
+++ b/DevSkim-DotNet/Microsoft.DevSkim/Microsoft.DevSkim.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.CST.ApplicationInspector.RulesEngine" Version="1.9.9" />
+      <PackageReference Include="Microsoft.CST.ApplicationInspector.RulesEngine" Version="1.9.10" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 


### PR DESCRIPTION
The schema pointed to by the sarif-sdk is now available, removing the workaround in the sarif writer.
Fixes #582 
Also updates dependencies.