### PR TITLE
Update Actions and runners

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   Check-Changelog:
     name: Check Changelog Action
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: tarides/changelog-check-action@v2
         with:

--- a/.github/workflows/publish-api-docs.yml
+++ b/.github/workflows/publish-api-docs.yml
@@ -30,12 +30,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v3
       # Install .NET and DocFx
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.x'
       - name: Install docfx
@@ -45,7 +45,7 @@ jobs:
         run: docfx docfx_project/docfx.json
       # Upload constructed site
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v2
         with:
           path: 'docfx_project/_site'
       # deploy to GitHub Pages

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.21] - 2023-09-11
+### Dependencies
+Update action versions for github workflows.
+
 ## [1.0.20] - 2023-08-28
 ### Fixes
 Removes workaround for 404 sarif schema uri


### PR DESCRIPTION
Updated Actions:
  - checkout: v3 -> v4
  - setup-dotnet: v1 -> v3
  - upload-pages-artifact: v1 -> v2
 
Updated runner:
  - ubuntu: 20.04 -> latest (22.04)

Fixes #584