### PR TITLE
Move Github Release task to last item in CLI publish

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.27] - 2023-12-12
+### Pipelines
+Move GitHub Release task to last task in publish pipeline.
+
 ## [1.0.26] - 2023-12-05
 ### Dependencies
 Update dependencies.

--- a/Pipelines/cli/devskim-cli-release.yml
+++ b/Pipelines/cli/devskim-cli-release.yml
@@ -481,21 +481,6 @@ stages:
       inputs:
         targetPath: '$(Build.StagingDirectory)'
         artifact: 'Signed_Binaries'
-    - task: GitHubRelease@1
-      displayName: Release to GitHub
-      inputs:
-        gitHubConnection: 'DevSkim'
-        repositoryName: 'microsoft/DevSkim'
-        action: 'create'
-        target: '$(Build.SourceVersion)'
-        tagSource: 'userSpecifiedTag'
-        tag: 'v$(ReleaseVersion)'
-        title: 'DevSkim CLI v$(ReleaseVersion)'
-        assets: |
-          $(Build.StagingDirectory)/*.zip
-          $(Build.StagingDirectory)/HASHES.txt
-        changeLogCompareToRelease: 'lastNonDraftRelease'
-        changeLogType: 'commitBased'
     - task: NuGetCommand@2
       displayName: Publish NuGet Packages
       inputs:
@@ -551,3 +536,18 @@ stages:
       inputs:
         PathtoPublish: '$(Build.StagingDirectory)/Manifests'
         ArtifactName: 'Release Manifests'
+    - task: GitHubRelease@1
+      displayName: Release to GitHub
+      inputs:
+        gitHubConnection: 'DevSkim'
+        repositoryName: 'microsoft/DevSkim'
+        action: 'create'
+        target: '$(Build.SourceVersion)'
+        tagSource: 'userSpecifiedTag'
+        tag: 'v$(ReleaseVersion)'
+        title: 'DevSkim CLI v$(ReleaseVersion)'
+        assets: |
+          $(Build.StagingDirectory)/*.zip
+          $(Build.StagingDirectory)/HASHES.txt
+        changeLogCompareToRelease: 'lastNonDraftRelease'
+        changeLogType: 'commitBased'


### PR DESCRIPTION
Have been having issues with the github release task failing. It should run after the nuget release task to avoid missing publication to nuget.