### PR TITLE
Add Job Id to the Signed_Binaries pipeline artifact name

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.31] - 2024-1-28
+## [1.0.32] - 2024-3-04
+### Pipeline
+Improvement to pipeline to allow rerunning failed deploy jobs.
+
+## [1.0.31] - 2024-2-28
 ### Sarif Format
 Populate additional fields for GitHub Code scanning
 

--- a/Pipelines/cli/devskim-cli-release.yml
+++ b/Pipelines/cli/devskim-cli-release.yml
@@ -480,7 +480,7 @@ stages:
       displayName: Publish Signed Artifacts to Pipeline
       inputs:
         targetPath: '$(Build.StagingDirectory)'
-        artifact: 'Signed_Binaries'
+        artifact: 'Signed_Binaries_$(System.JobId)_$(System.JobAttempt)'
     - task: NuGetCommand@2
       displayName: Publish NuGet Packages
       inputs:

--- a/Pipelines/vs/devskim-visualstudio-release.yml
+++ b/Pipelines/vs/devskim-visualstudio-release.yml
@@ -148,7 +148,7 @@ stages:
       displayName: Publish Signed Artifact to Pipeline
       inputs:
         targetPath: '$(Build.StagingDirectory)'
-        artifact: 'Signed_Extension'
+        artifact: 'Signed_Extension_$(System.JobId)_$(System.JobAttempt)'
     - task: PowerShell@2
       displayName: Move VS Marketplace Manifest
       inputs:

--- a/Pipelines/vscode/devskim-vscode-release.yml
+++ b/Pipelines/vscode/devskim-vscode-release.yml
@@ -195,7 +195,7 @@ stages:
       displayName: Publish Signed Artifact to Pipeline
       inputs:
         targetPath: '$(Build.StagingDirectory)'
-        artifact: 'Signed_Plugin'
+        artifact: 'Signed_Plugin_$(System.JobId)_$(System.JobAttempt)'
     - task: Npm@1
       displayName: Install vsce
       inputs:


### PR DESCRIPTION
If the pipeline fails during deployment the failed job cannot be rerun because this task will fail because the signed_binaries artifact already exists. However, the entire task also can't be re-run because the extensions have already been published by the time it hits this point. This PR adds a unique value so the failed job can be rerun in the case of temporary failures like API key rotations.