### PR TITLE
Fix Default Option Settings When Deserializing Options Json

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.33] - 2024-3-13
+### Fix
+Fixes properly setting the default value for the `OutputFileFormat` and `OutputTextFormat` fields when using the `options-json` argument to the analyze command.
+
 ## [1.0.32] - 2024-3-04
 ### Pipeline
 Improvement to pipeline to allow rerunning failed deploy jobs.

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/BaseAnalyzeCommandOptions.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/BaseAnalyzeCommandOptions.cs
@@ -31,10 +31,10 @@ public record BaseAnalyzeCommandOptions : LogOptions
     public string CommentsPath { get; set; } = string.Empty;
 
     [Option('o', "output-format", HelpText = "Format for output text.", Default = SimpleTextWriter.DefaultFormat)]
-    public string OutputTextFormat { get; set; } = string.Empty;
+    public string OutputTextFormat { get; set; } = SimpleTextWriter.DefaultFormat;
 
     [Option('f', "file-format", HelpText = "Format type for output. [text|sarif]", Default = "sarif")]
-    public string OutputFileFormat { get; set; } = string.Empty;
+    public string OutputFileFormat { get; set; } = "sarif";
 
     [Option('s', "severity", HelpText = "Comma-separated Severities to match", Separator = ',', Default = new[] { Severity.Critical, Severity.Important, Severity.Moderate, Severity.BestPractice, Severity.ManualReview })]
     public IEnumerable<Severity> Severities { get; set; } = new[] { Severity.Critical, Severity.Important, Severity.Moderate, Severity.BestPractice, Severity.ManualReview };


### PR DESCRIPTION
OutputTextFormat and OutputFileFormat were defaulting to string.Empty when deserialized because the default set for instantiating differed from the default value used for command parsing.

See https://github.com/microsoft/DevSkim-Action/issues/26