### PR TITLE
Fix #620

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.39] - 20224-6-26
+## [1.0.40] - 2024-7-08
+## Fix
+Fixes extraneous printing of git errors when git ignore checking is enabled during analysis.
+
+## [1.0.39] - 2024-6-26
 ### Pipelines
 Pipeline maintenance.
 

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/AnalyzeCommand.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/AnalyzeCommand.cs
@@ -267,7 +267,8 @@ namespace Microsoft.DevSkim.CLI.Commands
             {
                 Arguments = $"check-ignore {fp}",
                 WorkingDirectory = Directory.GetParent(fp)?.FullName,
-                RedirectStandardOutput = true
+                RedirectStandardOutput = true,
+                RedirectStandardError = true // Suppress git errors being printed - particularly when not in a git work tree
             });
             process?.WaitForExit();
             string? stdOut = process?.StandardOutput.ReadToEnd();


### PR DESCRIPTION
Fixes printing git errors to console when option to check git status is enabled. Git will print an error if checking status of a file that's not in a work tree - for example, the files in the `.git` folder, but the errors only indicate that ignore status could not be checked, which means the file is not ignored and thus not an error from DevSkim's perspective.