### PR TITLE
Fix rewriting files with no issues to suppress

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.42] - 2024-08-26
+## Fix
+Fixes suppression command to not perturb line breaks, particularly when a file has findings which are not selected for suppression.
+
 ## [1.0.41] - 2024-08-23
 ## Rules
 Extend the false positive fix for the issue reported in #548 to Sdk-style msbuild projects.

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.39] - 20224-6-26
+## [1.0.40] - 2024-7-08
+## Fix
+Fixes extraneous printing of git errors when git ignore checking is enabled during analysis.
+
+## [1.0.39] - 2024-6-26
 ### Pipelines
 Pipeline maintenance.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.42] - 2024-08-26
 ## Fix
-Fixes suppression command to not perturb line breaks, particularly when a file has findings which are not selected for suppression.
+Fixes suppression command to not perturb line breaks, particularly when a file has findings which are not selected for suppression. #631
 
 ## [1.0.41] - 2024-08-23
 ## Rules

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/AnalyzeCommand.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/AnalyzeCommand.cs
@@ -267,7 +267,8 @@ namespace Microsoft.DevSkim.CLI.Commands
             {
                 Arguments = $"check-ignore {fp}",
                 WorkingDirectory = Directory.GetParent(fp)?.FullName,
-                RedirectStandardOutput = true
+                RedirectStandardOutput = true,
+                RedirectStandardError = true // Suppress git errors being printed - particularly when not in a git work tree
             });
             process?.WaitForExit();
             string? stdOut = process?.StandardOutput.ReadToEnd();

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/SuppressionCommand.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Commands/SuppressionCommand.cs
@@ -61,6 +61,12 @@ namespace Microsoft.DevSkim.CLI.Commands
                         issueRecords = issueRecords.Where(x => _opts.RulesToApplyFrom.Any(y => y == x.RuleId)).ToList();
                     }
 
+                    // No issues remain for file after filtering to specified rule ids, skip file
+                    if (!issueRecords.Any())
+                    {
+                        continue;
+                    }
+                    
                     issueRecords
                     .Sort((a, b) => a.PhysicalLocation.Region.StartLine - b.PhysicalLocation.Region.StartLine);
 

--- a/DevSkim-DotNet/Microsoft.DevSkim.Tests/SuppressionsTest.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.Tests/SuppressionsTest.cs
@@ -290,19 +290,23 @@ namespace Microsoft.DevSkim.Tests
         /// <summary>
         /// Test that suppressing an issue doesn't change the line break characters
         /// </summary>
-        /// <param name="lineBreakSequence"></param>
+        /// <param name="lineBreakSequence">Character sequence used for line breaks</param>
+        /// <param name="preferMultiLine">Use multiline comments or not</param>
         [DataTestMethod]
-        [DataRow("\r\n")]
-        [DataRow("\n")]
-        public void DontPerturbExtantLineBreaks(string lineBreakSequence)
+        [DataRow("\r\n", true)]
+        [DataRow("\r\n", false)]
+        [DataRow("\n", true)]
+        [DataRow("\n", false)]
+        public void DontPerturbExtantLineBreaks(string lineBreakSequence, bool preferMultiLine)
         {
-            (string basePath, string sourceFile, string sarifPath) = runAnalysis($"MD5{lineBreakSequence}http://contoso.com{lineBreakSequence}", "c");
+            (string basePath, string sourceFile, string sarifPath) = runAnalysis($"MD5\\{lineBreakSequence}http://contoso.com{lineBreakSequence}", "c");
 
             SuppressionCommandOptions opts = new SuppressionCommandOptions
             {
                 Path = basePath,
                 SarifInput = sarifPath,
-                ApplyAllSuppression = true
+                ApplyAllSuppression = true,
+                PreferMultiline = preferMultiLine
             };
 
             int resultCode = new SuppressionCommand(opts).Run();
@@ -314,11 +318,14 @@ namespace Microsoft.DevSkim.Tests
         /// <summary>
         /// Test that files don't change at all when they have findings but those rule ids are not selected for suppression
         /// </summary>
-        /// <param name="lineBreakSequence"></param>
+        /// <param name="lineBreakSequence">Character sequence used for line breaks</param>
+        /// <param name="preferMultiLine">Use multiline comments or not</param>
         [DataTestMethod]
-        [DataRow("\r\n")]
-        [DataRow("\n")]
-        public void DontChangeFilesWithoutSelectedFindings(string lineBreakSequence)
+        [DataRow("\r\n", true)]
+        [DataRow("\r\n", false)]
+        [DataRow("\n", true)]
+        [DataRow("\n", false)]
+        public void DontChangeFilesWithoutSelectedFindings(string lineBreakSequence, bool preferMultiline)
         {
             string originalContent = $"MD5{lineBreakSequence}http://contoso.com{lineBreakSequence}";
             (string basePath, string sourceFile, string sarifPath) = runAnalysis(originalContent, "c");
@@ -328,6 +335,7 @@ namespace Microsoft.DevSkim.Tests
                 Path = basePath,
                 SarifInput = sarifPath,
                 ApplyAllSuppression = false,
+                PreferMultiline = preferMultiline,
                 RulesToApplyFrom = new string[] { "NotAValidRuleId" } // Don't apply any rules
             };
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The Visual Studio extension is available in the [Visual Studio Marketplace](http
 
 The Visual Studio Code plugin is available in the [Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=MS-CST-E.vscode-devskim).
 
-DevSkim is also available as a [GitHub Action](https://github.com/microsoft/DevSkim-Action) to itegrate with the GitHub Security Issues pane.
+DevSkim is also available as a [GitHub Action](https://github.com/microsoft/DevSkim-Action) to integrate with the GitHub Security Issues pane.
 
 Platform specific binaries of the DevSkim CLI are also available on our GitHub [releases page](https://github.com/microsoft/DevSkim/releases).
 


### PR DESCRIPTION
Fixes an issue where the Suppress command would rewrite a file essentially as is (but potentially change whitespace) even if all the detected issues in the file were filtered out by the rule filter.

Also fixes changing the newline characters when actually adding suppressions to a file (could occur when `Environment.NewLine` doesn't match the newline characters used in the extant file).

Adds new test cases for same.

Fix #631

Fix Readme Typo
Fix #626 
