### PR TITLE
Use MSTest SDK

### DIFF
--- a/DevSkim-DotNet/Microsoft.DevSkim.Tests/Microsoft.DevSkim.Tests.csproj
+++ b/DevSkim-DotNet/Microsoft.DevSkim.Tests/Microsoft.DevSkim.Tests.csproj
@@ -1,18 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="MSTest.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-
-        <IsPackable>false</IsPackable>
     </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
-        <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
-    </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\Microsoft.DevSkim.CLI\Microsoft.DevSkim.CLI.csproj" />

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+	"msbuild-sdks": {
+	  "MSTest.Sdk": "3.5.2"
+	}
+}


### PR DESCRIPTION
Update the test project to use `MSTest SDK` ([documentation](https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-sdk) and [blogpost](https://devblogs.microsoft.com/dotnet/introducing-mstest-sdk/)).

Updates to latest version (from 3.2.2 to 3.5.2).

This is also enabling the use of MSTest runner ([documentation](https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-runner-intro) and [blogpost](https://devblogs.microsoft.com/dotnet/introducing-ms-test-runner/)).