### PR TITLE
[False Positive][False Negative] Outdated/Banned SSL/TLS protocols

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+## Rules
+Fixed false positives and false negatives in outdated/banned SSL/TLS protocols. #649
+
 ## [1.0.42] - 2024-08-26
 ## Fix
 Fixes suppression command to not perturb line breaks, particularly when a file has findings which are not selected for suppression. #631

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.48]
 ## Rules
 Fixed false positives and false negatives in outdated/banned SSL/TLS protocols. #649
 

--- a/rules/default/security/cryptography/protocol.json
+++ b/rules/default/security/cryptography/protocol.json
@@ -82,7 +82,7 @@
         "rule_info": "DS169126.md",
         "patterns": [
             {
-                "pattern": "(SSLv?2|SSLv?3|TLSv?1|TLSv?10)",
+                "pattern": "(SSLv?2|SSLv?3|TLSv?1(?![._]?[2-9])|TLSv?1[._]?[01])",
                 "type": "RegexWord",
                 "scopes": [
                     "code"
@@ -90,9 +90,23 @@
             }
         ],
         "must-match": [
+            "SSLv2",
             "SSLv3",
             "TLSv1",
-            "TLSv10"
+            "TLSv10",
+            "TLSv1_0",
+            "TLSv1.0",
+            "TLSv11",
+            "TLSv1_1",
+            "TLSv1.1"
+        ],
+        "must-not-match": [
+            "TLSv12",
+            "TLSv1_2",
+            "TLSv1.2",
+            "TLSv13",
+            "TLSv1_3",
+            "TLSv1.3"
         ]
     },
     {
@@ -129,22 +143,8 @@
                 ]
             },
             {
-                "pattern": "TLSv1(?!_[2-9])",
+                "pattern": "TLSv1(?![._]?[2-9])",
                 "type": "regex",
-                "scopes": [
-                    "code"
-                ]
-            },
-            {
-                "pattern": "TLSv1(0|_0)",
-                "type": "regex",
-                "scopes": [
-                    "code"
-                ]
-            },
-            {
-                "pattern": "TLSv1_1",
-                "type": "string",
                 "scopes": [
                     "code"
                 ]
@@ -154,11 +154,21 @@
             "SSLv3",
             "TLSv1",
             "TLSv10",
+            "TLSv1.0",
+            "TLSv1_0",
+            "TLSv11",
+            "TLSv1.1",
+            "TLSv1_1",
+            "TLSv1X9",
             "SSLv2_client"
         ],
         "must-not-match":[
+            "TLSv12",
             "TLSv1_2",
-            "TLSv1_3"
+            "TLSv1.2",
+            "TLSv13",
+            "TLSv1_3",
+            "TLSv1.3"
         ]
     },
     {


### PR DESCRIPTION
## Rule ID

DS169125 Do not use outdated SSL/TLS protocols
DS169126 An Outdated or Banned SSL/TLS Protocol is Used

## What the rule matched

DS169125
* TLSv1.2
* TLSv1.3 

DS169126
* TLSv12 
* TLSv1.2 
* TLSv13 
* TLSv1.3

## Why should this not be matched?

https://github.com/microsoft/DevSkim/blob/v1.0.33/guidance/DS169126.md says:
> Use TLSv1.3 if possible or TLSv1.2 if 1.3 cannot be used.

## What the rule did not match (false negative)

DS169125
* TLSv1_0 
* TLSv11
* TLSv1_1

 ## Why should this be matched?

https://github.com/microsoft/DevSkim/blob/v1.0.33/guidance/DS169126.md says:
>TLSv1 - Weak, strongly consider disabling unless absolutely required.
>TLSv1.1 - Weak, strongly consider disabling unless absolutely required.

It already matches TLSv10 and TLSv1.0, therefore it should also match TLSv1_0. It already matches TLSv1.1, therefore it should also match TLSv11 and TLSv1_1.