### PR TITLE
Add MSBuild Diagnostic Format Output Option

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.58] - 2025-06-09
+## New Feature
+Adds a `vs` output format to leverage the DevSkim CLI as a build task in a csproj.
+
 ## [1.0.57] - 2025-05-28
 ## Fix
 Fix an issue handling non-ascii paths when launching LSP in VS Code Extension

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/BaseAnalyzeCommandOptions.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Options/BaseAnalyzeCommandOptions.cs
@@ -33,7 +33,7 @@ public record BaseAnalyzeCommandOptions : LogOptions
     [Option('o', "output-format", HelpText = "Format for output text.", Default = SimpleTextWriter.DefaultFormat)]
     public string OutputTextFormat { get; set; } = SimpleTextWriter.DefaultFormat;
 
-    [Option('f', "file-format", HelpText = "Format type for output. [text|sarif]", Default = "sarif")]
+    [Option('f', "file-format", HelpText = "Format type for output. [text|sarif|vs]", Default = "sarif")]
     public string OutputFileFormat { get; set; } = "sarif";
 
     [Option('s', "severity", HelpText = "Comma-separated Severities to match", Separator = ',', Default = new[] { Severity.Critical, Severity.Important, Severity.Moderate, Severity.BestPractice, Severity.ManualReview })]

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SimpleTextWriter.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SimpleTextWriter.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.IO;
+using Microsoft.ApplicationInspector.RulesEngine;
 
 namespace Microsoft.DevSkim.CLI.Writers
 {
@@ -16,6 +17,7 @@ namespace Microsoft.DevSkim.CLI.Writers
     ///     - %R - rule id
     ///     - %N - rule name
     ///     - %S - severity (Critical, Important, etc.)
+    ///     - %V - Visual Studio style severity (only warning or error)
     ///     - %m - string match
     ///     - %T - tags(comma-separated)
     /// </summary>
@@ -62,10 +64,25 @@ namespace Microsoft.DevSkim.CLI.Writers
             output = output.Replace("%R", issue.Issue.Rule.Id);
             output = output.Replace("%N", issue.Issue.Rule.Name);
             output = output.Replace("%S", issue.Issue.Rule.Severity.ToString());
+            output = output.Replace("%V", DevSkimSevToVsSev(issue.Issue.Rule.Severity));
             output = output.Replace("%D", issue.Issue.Rule.Description);
             output = output.Replace("%m", issue.TextSample);
             output = output.Replace("%T", string.Join(",", issue.Issue.Rule.Tags ?? Array.Empty<string>()));
             TextWriter.WriteLine(output);
+        }
+
+        private string DevSkimSevToVsSev(Severity ruleSeverity)
+        {
+            return ruleSeverity switch
+            {
+                Severity.Unspecified => "unspecified",
+                Severity.Critical => "error",
+                Severity.Important => "warning",
+                Severity.Moderate => "warning",
+                Severity.BestPractice => "warning",
+                Severity.ManualReview => "warning",
+                _ => "unspecified"
+            };
         }
 
         private string _formatString;

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/WriterFactory.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/WriterFactory.cs
@@ -19,6 +19,9 @@ namespace Microsoft.DevSkim.CLI.Writers
                 case "_dummy":
                     return new DummyWriter();
 
+                case "vs":
+                    return new SimpleTextWriter("%F(%L,%l): %V %R: %D", output);
+                
                 case "json":
                     return new JsonWriter(format, output);
 


### PR DESCRIPTION
Adds an output format to use devskim in a csproj build task to populate the diagnostic window.

Intended as an alternative to the VS extension.

To use, one would add something like the following to your csproj (this specific example assuming having the devskim tool installed on your system path like with `dotnet tool install -g Microsoft.CST.DevSkim.CLI`).

```xml
  <Target Name="Run DevSkim" BeforeTargets="Build">
    <Exec Command="devskim analyze -I . -f vs" />
  </Target>
```