### PR TITLE
Bumps npm dependencies and DevSkim .NET dependencies, Fix #697

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.63] - 2025-07-29
+## Dependencies
+Update dependencies 
+
 ## [1.0.62] - 2025-07-23
 ## Pipelines
 Pipeline updates

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,75 +5,78 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.0.63] - 2025-07-29
-## Dependencies
+### Fix
+Fixes Sarif Markdown value failing to populate the rule provided recommendation value. #697
+
+### Dependencies
 Update dependencies 
 
-## Fix
-Fixes Sarif Markdown failing to populate the rule provided recommendation value.
+### Tests
+Adds test cases for SarifWriter
 
 ## [1.0.62] - 2025-07-23
-## Pipelines
+### Pipelines
 Pipeline updates
 
 ## [1.0.61] - 2025-07-11
-## Pipelines
+### Pipelines
 Pipeline updates
 
 ## [1.0.60] - 2025-06-36
-## Pipelines
+### Pipelines
 Pipeline updates
 
 ## [1.0.59] - 2025-06-10
-## Misc (non-code)
+### Misc (non-code)
 Removes old doc publish workflow. 
 
 ## [1.0.58] - 2025-06-09
-## New Feature
+### New Feature
 Adds a `vs` output format to leverage the DevSkim CLI as a build task in a csproj.
 
 ## [1.0.57] - 2025-05-28
-## Fix
+### Fix
 Fix an issue handling non-ascii paths when launching LSP in VS Code Extension
 
-## Dependencies
+### Dependencies
 Update Dependencies
 
 ## [1.0.56] - 2025-04-14
-## Tests
+### Tests
 Migrate to MTP
 
 ## [1.0.55] - 2025-04-14
-## Dependencies
+### Dependencies
 Updates Dependencies
 
 ## [1.0.54] - 2025-04-09
-## Dependencies
+### Dependencies
 Updates Dependencies
 
 ## [1.0.53] - 2025-04-01
-## Documentation
+### Documentation
 Adds a link to the Microsoft Privacy Statement to the Readme.
 
 ## [1.0.52] - 2024-12-09
-## Dependencies
+### Dependencies
 Updates Dependencies
 
-## .Net Targets
+### .Net Targets
 CLI now targets .NET 8.0 and .NET 9.0, .NET 6.0/7.0 targeting removed. DevSkim Library component retains .Net Standard 2.1 support.
 
 ## [1.0.51] - 2024-12-09
-## Fix
+### Fix
 Fix confidence filtering at rule level.
 
 ## [1.0.50] - 2024-12-05
-## Fix
+### Fix
 Fixes #664 handling of options from IgnoreRuleMap when using OptionsJson
 
-## New Functionality
+### New Functionality
 Adds `include-globs` argument to require all scanned files match a specific glob pattern #663.
 
 ## [1.0.49] - 2024-12-03
-## Rules
+### Rules
 Fixed false positives and false negatives in outdated/banned SSL/TLS protocols. #649
 
 ## [1.0.48] - 2024-11-20

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Dependencies
 Update dependencies 
 
+## Fix
+Fixes Sarif Markdown failing to populate the rule provided recommendation value.
+
 ## [1.0.62] - 2025-07-23
 ## Pipelines
 Pipeline updates

--- a/Changelog.md
+++ b/Changelog.md
@@ -22,7 +22,7 @@ Pipeline updates
 ### Pipelines
 Pipeline updates
 
-## [1.0.60] - 2025-06-36
+## [1.0.60] - 2025-06-26
 ### Pipelines
 Pipeline updates
 

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Microsoft.DevSkim.CLI.csproj
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Microsoft.DevSkim.CLI.csproj
@@ -25,6 +25,10 @@
     <LangVersion>10.0</LangVersion>
     <Nullable>Enable</Nullable>        
   </PropertyGroup>
+  
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.DevSkim.Tests" />
+  </ItemGroup>
     <ItemGroup>
         <None Include="..\Content\LICENSE.txt" Pack="true" PackagePath="" />
         <None Include="..\Content\devskim-icon-128.png" Pack="true" PackagePath="" />

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
@@ -191,23 +191,25 @@ namespace Microsoft.DevSkim.CLI.Writers
 
         public string? OutputPath { get; }
 
+        public const string baseHelpUri = "https://github.com/Microsoft/DevSkim/blob/main/guidance/";
+
         private void AddRuleToSarifRule(DevSkimRule devskimRule)
         {
             if (!_rules.ContainsKey(devskimRule.Id))
             {
-                Uri helpUri = new Uri("https://github.com/Microsoft/DevSkim/blob/main/guidance/" + devskimRule.RuleInfo); ;
+                Uri helpUri = CreateHelpUri(devskimRule.RuleInfo);
                 ReportingDescriptor sarifRule = new ReportingDescriptor();
                 sarifRule.Id = devskimRule.Id;
                 sarifRule.Name = ToSarifFriendlyName(devskimRule.Name);
                 sarifRule.ShortDescription = new MultiformatMessageString() { Text = devskimRule.Description };
                 sarifRule.FullDescription = new MultiformatMessageString() { Text = $"{devskimRule.Name}: {devskimRule.Description}" };
-                
+
                 sarifRule.Help = new MultiformatMessageString()
                 {
                     Text = BuildTextDescription(devskimRule, helpUri),
                     Markdown = BuildMarkdownDescription(devskimRule, helpUri)
                 };
-                
+
                 sarifRule.HelpUri = helpUri;
                 sarifRule.DefaultConfiguration = new ReportingConfiguration()
                 {
@@ -316,6 +318,25 @@ namespace Microsoft.DevSkim.CLI.Writers
             {
                 resultItem.Tags.Add(tag);
             }
+        }
+
+        /// <summary>
+        /// Creates a help URI for a DevSkim rule, handling null or empty RuleInfo safely
+        /// </summary>
+        /// <param name="ruleInfo">The rule info filename, can be null or empty</param>
+        /// <returns>A properly formed URI</returns>
+        public static Uri CreateHelpUri(string? ruleInfo)
+        {
+            var baseUri = new Uri(baseHelpUri);
+            
+            if (string.IsNullOrEmpty(ruleInfo))
+            {
+                // Return base URI if no specific rule info is provided
+                return baseUri;
+            }
+            
+            // Use Uri constructor to safely combine base URI with relative path
+            return new Uri(baseUri, ruleInfo);
         }
 
         /// <summary>

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
@@ -204,9 +204,7 @@ namespace Microsoft.DevSkim.CLI.Writers
                 
                 sarifRule.Help = new MultiformatMessageString()
                 {
-                    // If recommendation is present use that, otherwise use description if present, otherwise use the HelpUri
-                    Text = !string.IsNullOrEmpty(devskimRule.Recommendation) ? devskimRule.Recommendation : 
-                        (!string.IsNullOrEmpty(devskimRule.Description) ? devskimRule.Description : $"Visit {helpUri} for guidance on this issue."),
+                    Text = BuildTextDescription(devskimRule, helpUri),
                     Markdown = BuildMarkdownDescription(devskimRule, helpUri)
                 };
                 
@@ -318,6 +316,28 @@ namespace Microsoft.DevSkim.CLI.Writers
             {
                 resultItem.Tags.Add(tag);
             }
+        }
+
+        /// <summary>
+        /// Builds the text description for a SARIF rule based on the DevSkim rule properties
+        /// </summary>
+        /// <param name="devskimRule">The DevSkim rule containing recommendation and description</param>
+        /// <param name="helpUri">The help URI for the rule</param>
+        /// <returns>The text description string</returns>
+        private static string BuildTextDescription(DevSkimRule devskimRule, Uri helpUri)
+        {
+            // If recommendation is present use that, otherwise use description if present, otherwise use the HelpUri
+            if (!string.IsNullOrEmpty(devskimRule.Recommendation))
+            {
+                return devskimRule.Recommendation;
+            }
+            
+            if (!string.IsNullOrEmpty(devskimRule.Description))
+            {
+                return devskimRule.Description;
+            }
+            
+            return $"Visit {helpUri} for guidance on this issue.";
         }
 
         /// <summary>

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
@@ -205,7 +205,10 @@ namespace Microsoft.DevSkim.CLI.Writers
                 // If recommendation was present we should use that, but the description value was already set in the description field.
                 //  and also append the help uri if the rule_info is specified (for built-in rules)
                 StringBuilder markdownDescriptionBuilder = new();
-                markdownDescriptionBuilder.Append(devskimRule.Recommendation);
+                if (!string.IsNullOrEmpty(devskimRule.Recommendation))
+                {
+                    markdownDescriptionBuilder.Append(devskimRule.Recommendation);
+                }
                 if (!string.IsNullOrEmpty(devskimRule.RuleInfo))
                 {
                     // If a recommendation was set put a space before the rule info string.

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
@@ -325,7 +325,7 @@ namespace Microsoft.DevSkim.CLI.Writers
         /// </summary>
         /// <param name="ruleInfo">The rule info filename, can be null or empty</param>
         /// <returns>A properly formed URI</returns>
-        public static Uri CreateHelpUri(string? ruleInfo)
+        internal static Uri CreateHelpUri(string? ruleInfo)
         {
             var baseUri = new Uri(BaseHelpUri);
             

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
@@ -191,7 +191,7 @@ namespace Microsoft.DevSkim.CLI.Writers
 
         public string? OutputPath { get; }
 
-        public const string baseHelpUri = "https://github.com/Microsoft/DevSkim/blob/main/guidance/";
+        public const string BaseHelpUri = "https://github.com/Microsoft/DevSkim/blob/main/guidance/";
 
         private void AddRuleToSarifRule(DevSkimRule devskimRule)
         {
@@ -327,7 +327,7 @@ namespace Microsoft.DevSkim.CLI.Writers
         /// <returns>A properly formed URI</returns>
         public static Uri CreateHelpUri(string? ruleInfo)
         {
-            var baseUri = new Uri(baseHelpUri);
+            var baseUri = new Uri(BaseHelpUri);
             
             if (string.IsNullOrEmpty(ruleInfo))
             {

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
@@ -202,15 +202,18 @@ namespace Microsoft.DevSkim.CLI.Writers
                 sarifRule.ShortDescription = new MultiformatMessageString() { Text = devskimRule.Description };
                 sarifRule.FullDescription = new MultiformatMessageString() { Text = $"{devskimRule.Name}: {devskimRule.Description}" };
 
-                // If recommendation or description are present we should use that,
+                // If recommendation was present we should use that, but the description value was already set in the description field.
                 //  and also append the help uri if the rule_info is specified (for built-in rules)
                 StringBuilder markdownDescriptionBuilder = new();
-                markdownDescriptionBuilder.Append(!string.IsNullOrEmpty(devskimRule.Recommendation)
-                    ? devskimRule.Recommendation
-                    : devskimRule.Description);
+                markdownDescriptionBuilder.Append(devskimRule.Recommendation);
                 if (!string.IsNullOrEmpty(devskimRule.RuleInfo))
                 {
-                    markdownDescriptionBuilder.Append($"Visit [{helpUri}]({helpUri}) for guidance on this issue.");
+                    // If a recommendation was set put a space before the rule info string.
+                    if (markdownDescriptionBuilder.Length > 0)
+                    {
+                        markdownDescriptionBuilder.Append(' ');
+                    }
+                    markdownDescriptionBuilder.Append($"Visit [{helpUri}]({helpUri}) for additional guidance on this issue.");
                 }
                 
                 sarifRule.Help = new MultiformatMessageString()

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
@@ -325,7 +325,7 @@ namespace Microsoft.DevSkim.CLI.Writers
         /// </summary>
         /// <param name="ruleInfo">The rule info filename, can be null or empty</param>
         /// <returns>A properly formed URI</returns>
-        internal static Uri CreateHelpUri(string? ruleInfo)
+        public static Uri CreateHelpUri(string? ruleInfo)
         {
             var baseUri = new Uri(BaseHelpUri);
             

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
@@ -191,7 +191,7 @@ namespace Microsoft.DevSkim.CLI.Writers
 
         public string? OutputPath { get; }
 
-        public const string BaseHelpUri = "https://github.com/Microsoft/DevSkim/blob/main/guidance/";
+        private const string BaseHelpUri = "https://github.com/Microsoft/DevSkim/blob/main/guidance/";
 
         private void AddRuleToSarifRule(DevSkimRule devskimRule)
         {

--- a/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs
@@ -201,30 +201,13 @@ namespace Microsoft.DevSkim.CLI.Writers
                 sarifRule.Name = ToSarifFriendlyName(devskimRule.Name);
                 sarifRule.ShortDescription = new MultiformatMessageString() { Text = devskimRule.Description };
                 sarifRule.FullDescription = new MultiformatMessageString() { Text = $"{devskimRule.Name}: {devskimRule.Description}" };
-
-                // If recommendation was present we should use that, but the description value was already set in the description field.
-                //  and also append the help uri if the rule_info is specified (for built-in rules)
-                StringBuilder markdownDescriptionBuilder = new();
-                if (!string.IsNullOrEmpty(devskimRule.Recommendation))
-                {
-                    markdownDescriptionBuilder.Append(devskimRule.Recommendation);
-                }
-                if (!string.IsNullOrEmpty(devskimRule.RuleInfo))
-                {
-                    // If a recommendation was set put a space before the rule info string.
-                    if (markdownDescriptionBuilder.Length > 0)
-                    {
-                        markdownDescriptionBuilder.Append(' ');
-                    }
-                    markdownDescriptionBuilder.Append($"Visit [{helpUri}]({helpUri}) for additional guidance on this issue.");
-                }
                 
                 sarifRule.Help = new MultiformatMessageString()
                 {
                     // If recommendation is present use that, otherwise use description if present, otherwise use the HelpUri
                     Text = !string.IsNullOrEmpty(devskimRule.Recommendation) ? devskimRule.Recommendation : 
                         (!string.IsNullOrEmpty(devskimRule.Description) ? devskimRule.Description : $"Visit {helpUri} for guidance on this issue."),
-                    Markdown = markdownDescriptionBuilder.ToString()
+                    Markdown = BuildMarkdownDescription(devskimRule, helpUri)
                 };
                 
                 sarifRule.HelpUri = helpUri;
@@ -335,6 +318,34 @@ namespace Microsoft.DevSkim.CLI.Writers
             {
                 resultItem.Tags.Add(tag);
             }
+        }
+
+        /// <summary>
+        /// Builds the markdown description for a SARIF rule based on the DevSkim rule properties
+        /// </summary>
+        /// <param name="devskimRule">The DevSkim rule containing recommendation and rule info</param>
+        /// <param name="helpUri">The help URI for the rule</param>
+        /// <returns>The formatted markdown string</returns>
+        private static string BuildMarkdownDescription(DevSkimRule devskimRule, Uri helpUri)
+        {
+            StringBuilder markdownDescriptionBuilder = new();
+            
+            if (!string.IsNullOrEmpty(devskimRule.Recommendation))
+            {
+                markdownDescriptionBuilder.Append(devskimRule.Recommendation);
+            }
+            
+            if (!string.IsNullOrEmpty(devskimRule.RuleInfo))
+            {
+                // If a recommendation was set put a space before the rule info string.
+                if (markdownDescriptionBuilder.Length > 0)
+                {
+                    markdownDescriptionBuilder.Append(' ');
+                }
+                markdownDescriptionBuilder.Append($"Visit [{helpUri}]({helpUri}) for additional guidance on this issue.");
+            }
+            
+            return markdownDescriptionBuilder.ToString();
         }
     }
 }

--- a/DevSkim-DotNet/Microsoft.DevSkim.Tests/AnalyzeTest.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.Tests/AnalyzeTest.cs
@@ -20,7 +20,6 @@ namespace Microsoft.DevSkim.Tests
             File.Delete(outFileName);
 
             string basePath = Path.GetTempPath();
-            string oneUpPath = Directory.GetParent(basePath).FullName;
             using FileStream file = File.Open(tempFileName, FileMode.Create);
             file.Write(Encoding.UTF8.GetBytes("MD5;\nhttp://contoso.com\n"));
             file.Close();

--- a/DevSkim-DotNet/Microsoft.DevSkim.Tests/SarifWriterTests.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.Tests/SarifWriterTests.cs
@@ -1,0 +1,364 @@
+// Copyright (C) Microsoft. All rights reserved. Licensed under the MIT License.
+
+using Microsoft.DevSkim.CLI.Writers;
+using Microsoft.ApplicationInspector.RulesEngine;
+using Newtonsoft.Json.Linq;
+using AiLocation = Microsoft.ApplicationInspector.RulesEngine.Location;
+
+namespace Microsoft.DevSkim.Tests
+{
+    [TestClass]
+    public class SarifWriterTests
+    {
+        private StringWriter _writer = null!;
+        private SarifWriter _sarifWriter = null!;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            _writer = new StringWriter();
+            _sarifWriter = new SarifWriter(_writer, null, null);
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            _writer?.Dispose();
+        }
+
+        /// <summary>
+        /// Test that rules with recommendations properly include the recommendation in the SARIF Help field
+        /// </summary>
+        [TestMethod]
+        public void SarifWriter_RuleWithRecommendation_IncludesRecommendationInHelp()
+        {
+            // Arrange
+            const string expectedRecommendation = "Use a more secure hashing algorithm like SHA-256 instead of MD5.";
+            var rule = CreateTestRule("TEST001", "Test Rule", "Test description", expectedRecommendation);
+            var issue = CreateTestIssue(rule, "test.cs", "MD5 hash = MD5.Create();");
+
+            // Act
+            _sarifWriter.WriteIssue(issue);
+            _sarifWriter.FlushAndClose();
+
+            // Assert
+            var sarifOutput = ParseSarifOutput(_writer.ToString());
+            var sarifRule = GetRuleFromSarif(sarifOutput, "TEST001");
+            
+            Assert.IsNotNull(sarifRule);
+            Assert.AreEqual(expectedRecommendation, sarifRule!["help"]!["text"]!.ToString());
+        }
+
+        /// <summary>
+        /// Test that rules without recommendations fall back to description in the SARIF Help field
+        /// </summary>
+        [TestMethod]
+        public void SarifWriter_RuleWithoutRecommendation_FallsBackToDescriptionInHelp()
+        {
+            // Arrange
+            const string expectedDescription = "Test description for fallback";
+            var rule = CreateTestRule("TEST002", "Test Rule", expectedDescription, null);
+            var issue = CreateTestIssue(rule, "test.cs", "MD5 hash = MD5.Create();");
+
+            // Act
+            _sarifWriter.WriteIssue(issue);
+            _sarifWriter.FlushAndClose();
+
+            // Assert
+            var sarifOutput = ParseSarifOutput(_writer.ToString());
+            var sarifRule = GetRuleFromSarif(sarifOutput, "TEST002");
+            
+            Assert.IsNotNull(sarifRule);
+            Assert.AreEqual(expectedDescription, sarifRule!["help"]!["text"]!.ToString());
+        }
+
+        /// <summary>
+        /// Test that rules with recommendations and rule info include both in markdown help
+        /// </summary>
+        [TestMethod]
+        public void SarifWriter_RuleWithRecommendationAndRuleInfo_IncludesBothInMarkdown()
+        {
+            // Arrange
+            const string expectedRecommendation = "Use SHA-256 instead of MD5.";
+            const string ruleInfo = "DS126858.md";
+            var rule = CreateTestRule("TEST003", "Test Rule", "Test description", expectedRecommendation, ruleInfo);
+            var issue = CreateTestIssue(rule, "test.cs", "MD5 hash = MD5.Create();");
+
+            // Act
+            _sarifWriter.WriteIssue(issue);
+            _sarifWriter.FlushAndClose();
+
+            // Assert
+            var sarifOutput = ParseSarifOutput(_writer.ToString());
+            var sarifRule = GetRuleFromSarif(sarifOutput, "TEST003");
+            
+            Assert.IsNotNull(sarifRule);
+            
+            // Check text field has recommendation
+            Assert.AreEqual(expectedRecommendation, sarifRule!["help"]!["text"]!.ToString());
+            
+            // Check markdown field includes both recommendation and help URI
+            var markdown = sarifRule["help"]!["markdown"]!.ToString();
+            Assert.IsTrue(markdown.Contains(expectedRecommendation));
+            Assert.IsTrue(markdown.Contains("Visit [https://github.com/Microsoft/DevSkim/blob/main/guidance/DS126858.md]"));
+            Assert.IsTrue(markdown.Contains("for additional guidance on this issue"));
+        }
+
+        /// <summary>
+        /// Test that rules without recommendations but with rule info still include help URI
+        /// </summary>
+        [TestMethod]
+        public void SarifWriter_RuleWithoutRecommendationButWithRuleInfo_IncludesHelpUri()
+        {
+            // Arrange
+            const string ruleInfo = "DS126858.md";
+            var rule = CreateTestRule("TEST004", "Test Rule", "Test description", null, ruleInfo);
+            var issue = CreateTestIssue(rule, "test.cs", "MD5 hash = MD5.Create();");
+
+            // Act
+            _sarifWriter.WriteIssue(issue);
+            _sarifWriter.FlushAndClose();
+
+            // Assert
+            var sarifOutput = ParseSarifOutput(_writer.ToString());
+            var sarifRule = GetRuleFromSarif(sarifOutput, "TEST004");
+            
+            Assert.IsNotNull(sarifRule);
+            
+            // Should fallback to description in text field
+            Assert.AreEqual("Test description", sarifRule!["help"]!["text"]!.ToString());
+            
+            // Markdown should still include help URI
+            var markdown = sarifRule["help"]!["markdown"]!.ToString();
+            Assert.IsTrue(markdown.Contains("Visit [https://github.com/Microsoft/DevSkim/blob/main/guidance/DS126858.md]"));
+        }
+
+        /// <summary>
+        /// Test that rules with empty recommendation string behave like rules without recommendations
+        /// </summary>
+        [TestMethod]
+        public void SarifWriter_RuleWithEmptyRecommendation_FallsBackToDescription()
+        {
+            // Arrange
+            const string expectedDescription = "Test description for empty recommendation";
+            var rule = CreateTestRule("TEST005", "Test Rule", expectedDescription, "");
+            var issue = CreateTestIssue(rule, "test.cs", "MD5 hash = MD5.Create();");
+
+            // Act
+            _sarifWriter.WriteIssue(issue);
+            _sarifWriter.FlushAndClose();
+
+            // Assert
+            var sarifOutput = ParseSarifOutput(_writer.ToString());
+            var sarifRule = GetRuleFromSarif(sarifOutput, "TEST005");
+            
+            Assert.IsNotNull(sarifRule);
+            Assert.AreEqual(expectedDescription, sarifRule!["help"]!["text"]!.ToString());
+        }
+
+        /// <summary>
+        /// Test that rules with whitespace-only recommendation string result in empty help due to SARIF SDK serialization behavior
+        /// </summary>
+        [TestMethod]
+        public void SarifWriter_RuleWithWhitespaceRecommendation_ResultsInEmptyHelp()
+        {
+            // Arrange
+            const string expectedDescription = "Test description for whitespace recommendation";
+            const string whitespaceRecommendation = "   \t\n   ";
+            var rule = CreateTestRule("TEST006", "Test Rule", expectedDescription, whitespaceRecommendation);
+            var issue = CreateTestIssue(rule, "test.cs", "MD5 hash = MD5.Create();");
+
+            // Act
+            _sarifWriter.WriteIssue(issue);
+            _sarifWriter.FlushAndClose();
+
+            // Assert
+            var sarifJson = _writer.ToString();
+            var sarifOutput = ParseSarifOutput(sarifJson);
+            var sarifRule = GetRuleFromSarif(sarifOutput, "TEST006");
+            
+            Assert.IsNotNull(sarifRule, $"sarifRule should not be null. SARIF output: {sarifJson}");
+            
+            // The SARIF SDK appears to serialize whitespace-only text as empty objects
+            // So the help field exists but has no text/markdown properties
+            var help = sarifRule!["help"];
+            Assert.IsNotNull(help, "Help object should exist");
+            
+            // The text and markdown properties should be null/missing when they contain only whitespace
+            var helpText = help["text"];
+            var helpMarkdown = help["markdown"];
+            
+            Assert.IsNull(helpText, "Help text should be null for whitespace-only recommendation");
+            Assert.IsNull(helpMarkdown, "Help markdown should be null for whitespace-only recommendation");
+        }
+
+        /// <summary>
+        /// Test that rules without recommendation and without description fall back to generic help message
+        /// </summary>
+        [TestMethod]
+        public void SarifWriter_RuleWithoutRecommendationAndDescription_FallsBackToGenericHelp()
+        {
+            // Arrange
+            const string ruleInfo = "DS126858.md";
+            var rule = CreateTestRule("TEST007", "Test Rule", null, null, ruleInfo);
+            var issue = CreateTestIssue(rule, "test.cs", "MD5 hash = MD5.Create();");
+
+            // Act
+            _sarifWriter.WriteIssue(issue);
+            _sarifWriter.FlushAndClose();
+
+            // Assert
+            var sarifOutput = ParseSarifOutput(_writer.ToString());
+            var sarifRule = GetRuleFromSarif(sarifOutput, "TEST007");
+            
+            Assert.IsNotNull(sarifRule);
+            
+            var helpText = sarifRule!["help"]!["text"]!.ToString();
+            Assert.IsTrue(helpText.Contains("Visit https://github.com/Microsoft/DevSkim/blob/main/guidance/DS126858.md for guidance on this issue"));
+        }
+
+        /// <summary>
+        /// Test that multiple rules with different recommendation states are handled correctly
+        /// </summary>
+        [TestMethod]
+        public void SarifWriter_MultipleRulesWithDifferentRecommendations_HandledCorrectly()
+        {
+            // Arrange
+            var rule1 = CreateTestRule("TEST008", "Rule with recommendation", "Description 1", "Recommendation 1");
+            var rule2 = CreateTestRule("TEST009", "Rule without recommendation", "Description 2", null);
+            var issue1 = CreateTestIssue(rule1, "test1.cs", "MD5 hash = MD5.Create();");
+            var issue2 = CreateTestIssue(rule2, "test2.cs", "SHA1 hash = SHA1.Create();");
+
+            // Act
+            _sarifWriter.WriteIssue(issue1);
+            _sarifWriter.WriteIssue(issue2);
+            _sarifWriter.FlushAndClose();
+
+            // Assert
+            var sarifOutput = ParseSarifOutput(_writer.ToString());
+            
+            var sarifRule1 = GetRuleFromSarif(sarifOutput, "TEST008");
+            var sarifRule2 = GetRuleFromSarif(sarifOutput, "TEST009");
+            
+            Assert.IsNotNull(sarifRule1);
+            Assert.IsNotNull(sarifRule2);
+            
+            // Rule 1 should have recommendation in help text
+            Assert.AreEqual("Recommendation 1", sarifRule1!["help"]!["text"]!.ToString());
+            
+            // Rule 2 should fall back to description in help text
+            Assert.AreEqual("Description 2", sarifRule2!["help"]!["text"]!.ToString());
+        }
+
+        /// <summary>
+        /// Test that markdown field is properly formatted when recommendation is present
+        /// </summary>
+        [TestMethod]
+        public void SarifWriter_RecommendationPresent_MarkdownFieldProperlyFormatted()
+        {
+            // Arrange
+            const string recommendation = "Use bcrypt for password hashing.";
+            const string ruleInfo = "DS123456.md";
+            var rule = CreateTestRule("TEST010", "Password Hashing", "Weak password hashing", recommendation, ruleInfo);
+            var issue = CreateTestIssue(rule, "auth.cs", "MD5.HashData(password);");
+
+            // Act
+            _sarifWriter.WriteIssue(issue);
+            _sarifWriter.FlushAndClose();
+
+            // Assert
+            var sarifOutput = ParseSarifOutput(_writer.ToString());
+            var sarifRule = GetRuleFromSarif(sarifOutput, "TEST010");
+            
+            Assert.IsNotNull(sarifRule);
+            
+            var markdown = sarifRule!["help"]!["markdown"]!.ToString();
+            var expectedMarkdown = $"{recommendation} Visit [https://github.com/Microsoft/DevSkim/blob/main/guidance/{ruleInfo}](https://github.com/Microsoft/DevSkim/blob/main/guidance/{ruleInfo}) for additional guidance on this issue.";
+            
+            Assert.AreEqual(expectedMarkdown, markdown);
+        }
+
+        /// <summary>
+        /// Test that rule with only RuleInfo (no recommendation) has proper markdown
+        /// </summary>
+        [TestMethod]
+        public void SarifWriter_OnlyRuleInfo_MarkdownContainsHelpUri()
+        {
+            // Arrange
+            const string ruleInfo = "DS789012.md";
+            var rule = CreateTestRule("TEST011", "Test Rule", "Test description", null, ruleInfo);
+            var issue = CreateTestIssue(rule, "test.cs", "some code");
+
+            // Act
+            _sarifWriter.WriteIssue(issue);
+            _sarifWriter.FlushAndClose();
+
+            // Assert
+            var sarifOutput = ParseSarifOutput(_writer.ToString());
+            var sarifRule = GetRuleFromSarif(sarifOutput, "TEST011");
+            
+            Assert.IsNotNull(sarifRule);
+            
+            var markdown = sarifRule!["help"]!["markdown"]!.ToString();
+            var expectedMarkdown = $"Visit [https://github.com/Microsoft/DevSkim/blob/main/guidance/{ruleInfo}](https://github.com/Microsoft/DevSkim/blob/main/guidance/{ruleInfo}) for additional guidance on this issue.";
+            
+            Assert.AreEqual(expectedMarkdown, markdown);
+        }
+
+        #region Helper Methods
+
+        private DevSkimRule CreateTestRule(string id, string name, string? description, string? recommendation, string? ruleInfo = null)
+        {
+            return new DevSkimRule
+            {
+                Id = id,
+                Name = name,
+                Description = description ?? string.Empty,
+                Recommendation = recommendation,
+                RuleInfo = ruleInfo,
+                Severity = Severity.Important,
+                Confidence = Confidence.High,
+                Patterns = new[]
+                {
+                    new SearchPattern
+                    {
+                        Pattern = "MD5",
+                        PatternType = PatternType.Regex,
+                        Scopes = new[] { PatternScope.All }
+                    }
+                }
+            };
+        }
+
+        private IssueRecord CreateTestIssue(DevSkimRule rule, string filename, string textSample)
+        {
+            var boundary = new Boundary
+            {
+                Index = 0,
+                Length = textSample.Length
+            };
+
+            var issue = new Issue(
+                Boundary: boundary,
+                StartLocation: new AiLocation { Line = 1, Column = 1 },
+                EndLocation: new AiLocation { Line = 1, Column = textSample.Length + 1 },
+                Rule: rule
+            );
+
+            return new IssueRecord(filename, 0, textSample, issue, "csharp", null);
+        }
+
+        private JObject ParseSarifOutput(string sarifJson)
+        {
+            return JObject.Parse(sarifJson);
+        }
+
+        private JToken? GetRuleFromSarif(JObject sarifOutput, string ruleId)
+        {
+            var rules = sarifOutput.SelectTokens("$.runs[*].tool.driver.rules[*]");
+            return rules.FirstOrDefault(rule => rule["id"]?.ToString() == ruleId);
+        }
+
+        #endregion
+    }
+}

--- a/DevSkim-DotNet/Microsoft.DevSkim.Tests/SarifWriterTests.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.Tests/SarifWriterTests.cs
@@ -89,7 +89,8 @@ namespace Microsoft.DevSkim.Tests
             
             // Markdown should still include help URI
             var markdown = sarifRule["help"]!["markdown"]!.ToString();
-            Assert.IsTrue(markdown.Contains($"Visit [{SarifWriter.CreateHelpUri("DS126858.md")}]"));
+            var expectedMarkdown = $"Visit [{SarifWriter.CreateHelpUri("DS126858.md")}]({SarifWriter.CreateHelpUri("DS126858.md")}) for additional guidance on this issue.";
+            Assert.AreEqual(expectedMarkdown, markdown);
         }
 
         /// <summary>
@@ -179,7 +180,8 @@ namespace Microsoft.DevSkim.Tests
             Assert.IsNotNull(sarifRule);
             
             var helpText = sarifRule!["help"]!["text"]!.ToString();
-            Assert.IsTrue(helpText.Contains($"Visit {SarifWriter.CreateHelpUri("DS126858.md")} for guidance on this issue"));
+            var expectedHelpText = $"Visit {SarifWriter.CreateHelpUri("DS126858.md")} for guidance on this issue.";
+            Assert.AreEqual(expectedHelpText, helpText);
         }
 
         /// <summary>

--- a/DevSkim-DotNet/Microsoft.DevSkim.Tests/SarifWriterTests.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.Tests/SarifWriterTests.cs
@@ -10,21 +10,6 @@ namespace Microsoft.DevSkim.Tests
     [TestClass]
     public class SarifWriterTests
     {
-        private StringWriter _writer = null!;
-        private SarifWriter _sarifWriter = null!;
-
-        [TestInitialize]
-        public void TestInitialize()
-        {
-            _writer = new StringWriter();
-            _sarifWriter = new SarifWriter(_writer, null, null);
-        }
-
-        [TestCleanup]
-        public void TestCleanup()
-        {
-            _writer?.Dispose();
-        }
 
         /// <summary>
         /// Test that rules with recommendations properly include the recommendation in the SARIF Help field
@@ -37,12 +22,14 @@ namespace Microsoft.DevSkim.Tests
             var rule = CreateTestRule("TEST001", "Test Rule", "Test description", expectedRecommendation);
             var issue = CreateTestIssue(rule, "test.cs", "MD5 hash = MD5.Create();");
 
-            // Act
-            _sarifWriter.WriteIssue(issue);
-            _sarifWriter.FlushAndClose();
+            // Act & Assert
+            using var writer = new StringWriter();
+            using var sarifWriter = new SarifWriter(writer, null, null);
+            
+            sarifWriter.WriteIssue(issue);
+            sarifWriter.FlushAndClose();
 
-            // Assert
-            var sarifOutput = ParseSarifOutput(_writer.ToString());
+            var sarifOutput = ParseSarifOutput(writer.ToString());
             var sarifRule = GetRuleFromSarif(sarifOutput, "TEST001");
             
             Assert.IsNotNull(sarifRule);
@@ -60,12 +47,14 @@ namespace Microsoft.DevSkim.Tests
             var rule = CreateTestRule("TEST002", "Test Rule", expectedDescription, null);
             var issue = CreateTestIssue(rule, "test.cs", "MD5 hash = MD5.Create();");
 
-            // Act
-            _sarifWriter.WriteIssue(issue);
-            _sarifWriter.FlushAndClose();
+            // Act & Assert
+            using var writer = new StringWriter();
+            using var sarifWriter = new SarifWriter(writer, null, null);
+            
+            sarifWriter.WriteIssue(issue);
+            sarifWriter.FlushAndClose();
 
-            // Assert
-            var sarifOutput = ParseSarifOutput(_writer.ToString());
+            var sarifOutput = ParseSarifOutput(writer.ToString());
             var sarifRule = GetRuleFromSarif(sarifOutput, "TEST002");
             
             Assert.IsNotNull(sarifRule);
@@ -84,12 +73,14 @@ namespace Microsoft.DevSkim.Tests
             var rule = CreateTestRule("TEST003", "Test Rule", "Test description", expectedRecommendation, ruleInfo);
             var issue = CreateTestIssue(rule, "test.cs", "MD5 hash = MD5.Create();");
 
-            // Act
-            _sarifWriter.WriteIssue(issue);
-            _sarifWriter.FlushAndClose();
+            // Act & Assert
+            using var writer = new StringWriter();
+            using var sarifWriter = new SarifWriter(writer, null, null);
+            
+            sarifWriter.WriteIssue(issue);
+            sarifWriter.FlushAndClose();
 
-            // Assert
-            var sarifOutput = ParseSarifOutput(_writer.ToString());
+            var sarifOutput = ParseSarifOutput(writer.ToString());
             var sarifRule = GetRuleFromSarif(sarifOutput, "TEST003");
             
             Assert.IsNotNull(sarifRule);
@@ -115,12 +106,14 @@ namespace Microsoft.DevSkim.Tests
             var rule = CreateTestRule("TEST004", "Test Rule", "Test description", null, ruleInfo);
             var issue = CreateTestIssue(rule, "test.cs", "MD5 hash = MD5.Create();");
 
-            // Act
-            _sarifWriter.WriteIssue(issue);
-            _sarifWriter.FlushAndClose();
+            // Act & Assert
+            using var writer = new StringWriter();
+            using var sarifWriter = new SarifWriter(writer, null, null);
+            
+            sarifWriter.WriteIssue(issue);
+            sarifWriter.FlushAndClose();
 
-            // Assert
-            var sarifOutput = ParseSarifOutput(_writer.ToString());
+            var sarifOutput = ParseSarifOutput(writer.ToString());
             var sarifRule = GetRuleFromSarif(sarifOutput, "TEST004");
             
             Assert.IsNotNull(sarifRule);
@@ -144,12 +137,14 @@ namespace Microsoft.DevSkim.Tests
             var rule = CreateTestRule("TEST005", "Test Rule", expectedDescription, "");
             var issue = CreateTestIssue(rule, "test.cs", "MD5 hash = MD5.Create();");
 
-            // Act
-            _sarifWriter.WriteIssue(issue);
-            _sarifWriter.FlushAndClose();
+            // Act & Assert
+            using var writer = new StringWriter();
+            using var sarifWriter = new SarifWriter(writer, null, null);
+            
+            sarifWriter.WriteIssue(issue);
+            sarifWriter.FlushAndClose();
 
-            // Assert
-            var sarifOutput = ParseSarifOutput(_writer.ToString());
+            var sarifOutput = ParseSarifOutput(writer.ToString());
             var sarifRule = GetRuleFromSarif(sarifOutput, "TEST005");
             
             Assert.IsNotNull(sarifRule);
@@ -168,12 +163,14 @@ namespace Microsoft.DevSkim.Tests
             var rule = CreateTestRule("TEST006", "Test Rule", expectedDescription, whitespaceRecommendation);
             var issue = CreateTestIssue(rule, "test.cs", "MD5 hash = MD5.Create();");
 
-            // Act
-            _sarifWriter.WriteIssue(issue);
-            _sarifWriter.FlushAndClose();
+            // Act & Assert
+            using var writer = new StringWriter();
+            using var sarifWriter = new SarifWriter(writer, null, null);
+            
+            sarifWriter.WriteIssue(issue);
+            sarifWriter.FlushAndClose();
 
-            // Assert
-            var sarifJson = _writer.ToString();
+            var sarifJson = writer.ToString();
             var sarifOutput = ParseSarifOutput(sarifJson);
             var sarifRule = GetRuleFromSarif(sarifOutput, "TEST006");
             
@@ -203,12 +200,14 @@ namespace Microsoft.DevSkim.Tests
             var rule = CreateTestRule("TEST007", "Test Rule", null, null, ruleInfo);
             var issue = CreateTestIssue(rule, "test.cs", "MD5 hash = MD5.Create();");
 
-            // Act
-            _sarifWriter.WriteIssue(issue);
-            _sarifWriter.FlushAndClose();
+            // Act & Assert
+            using var writer = new StringWriter();
+            using var sarifWriter = new SarifWriter(writer, null, null);
+            
+            sarifWriter.WriteIssue(issue);
+            sarifWriter.FlushAndClose();
 
-            // Assert
-            var sarifOutput = ParseSarifOutput(_writer.ToString());
+            var sarifOutput = ParseSarifOutput(writer.ToString());
             var sarifRule = GetRuleFromSarif(sarifOutput, "TEST007");
             
             Assert.IsNotNull(sarifRule);
@@ -229,13 +228,15 @@ namespace Microsoft.DevSkim.Tests
             var issue1 = CreateTestIssue(rule1, "test1.cs", "MD5 hash = MD5.Create();");
             var issue2 = CreateTestIssue(rule2, "test2.cs", "SHA1 hash = SHA1.Create();");
 
-            // Act
-            _sarifWriter.WriteIssue(issue1);
-            _sarifWriter.WriteIssue(issue2);
-            _sarifWriter.FlushAndClose();
+            // Act & Assert
+            using var writer = new StringWriter();
+            using var sarifWriter = new SarifWriter(writer, null, null);
+            
+            sarifWriter.WriteIssue(issue1);
+            sarifWriter.WriteIssue(issue2);
+            sarifWriter.FlushAndClose();
 
-            // Assert
-            var sarifOutput = ParseSarifOutput(_writer.ToString());
+            var sarifOutput = ParseSarifOutput(writer.ToString());
             
             var sarifRule1 = GetRuleFromSarif(sarifOutput, "TEST008");
             var sarifRule2 = GetRuleFromSarif(sarifOutput, "TEST009");
@@ -262,12 +263,14 @@ namespace Microsoft.DevSkim.Tests
             var rule = CreateTestRule("TEST010", "Password Hashing", "Weak password hashing", recommendation, ruleInfo);
             var issue = CreateTestIssue(rule, "auth.cs", "MD5.HashData(password);");
 
-            // Act
-            _sarifWriter.WriteIssue(issue);
-            _sarifWriter.FlushAndClose();
+            // Act & Assert
+            using var writer = new StringWriter();
+            using var sarifWriter = new SarifWriter(writer, null, null);
+            
+            sarifWriter.WriteIssue(issue);
+            sarifWriter.FlushAndClose();
 
-            // Assert
-            var sarifOutput = ParseSarifOutput(_writer.ToString());
+            var sarifOutput = ParseSarifOutput(writer.ToString());
             var sarifRule = GetRuleFromSarif(sarifOutput, "TEST010");
             
             Assert.IsNotNull(sarifRule);
@@ -289,12 +292,14 @@ namespace Microsoft.DevSkim.Tests
             var rule = CreateTestRule("TEST011", "Test Rule", "Test description", null, ruleInfo);
             var issue = CreateTestIssue(rule, "test.cs", "some code");
 
-            // Act
-            _sarifWriter.WriteIssue(issue);
-            _sarifWriter.FlushAndClose();
+            // Act & Assert
+            using var writer = new StringWriter();
+            using var sarifWriter = new SarifWriter(writer, null, null);
+            
+            sarifWriter.WriteIssue(issue);
+            sarifWriter.FlushAndClose();
 
-            // Assert
-            var sarifOutput = ParseSarifOutput(_writer.ToString());
+            var sarifOutput = ParseSarifOutput(writer.ToString());
             var sarifRule = GetRuleFromSarif(sarifOutput, "TEST011");
             
             Assert.IsNotNull(sarifRule);

--- a/DevSkim-DotNet/Microsoft.DevSkim.Tests/SarifWriterTests.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.Tests/SarifWriterTests.cs
@@ -62,40 +62,6 @@ namespace Microsoft.DevSkim.Tests
         }
 
         /// <summary>
-        /// Test that rules with recommendations and rule info include both in markdown help
-        /// </summary>
-        [TestMethod]
-        public void When_rule_has_recommendation_and_rule_info_then_markdown_includes_both()
-        {
-            // Arrange
-            const string expectedRecommendation = "Use SHA-256 instead of MD5.";
-            const string ruleInfo = "DS126858.md";
-            var rule = CreateTestRule("TEST003", "Test Rule", "Test description", expectedRecommendation, ruleInfo);
-            var issue = CreateTestIssue(rule, "test.cs", "MD5 hash = MD5.Create();");
-
-            // Act & Assert
-            using var writer = new StringWriter();
-            using var sarifWriter = new SarifWriter(writer, null, null);
-            
-            sarifWriter.WriteIssue(issue);
-            sarifWriter.FlushAndClose();
-
-            var sarifOutput = JObject.Parse(writer.ToString());
-            var sarifRule = GetRuleFromSarif(sarifOutput, "TEST003");
-            
-            Assert.IsNotNull(sarifRule);
-            
-            // Check text field has recommendation
-            Assert.AreEqual(expectedRecommendation, sarifRule!["help"]!["text"]!.ToString());
-            
-            // Check markdown field includes both recommendation and help URI
-            var markdown = sarifRule["help"]!["markdown"]!.ToString();
-            Assert.IsTrue(markdown.Contains(expectedRecommendation));
-            Assert.IsTrue(markdown.Contains("Visit [https://github.com/Microsoft/DevSkim/blob/main/guidance/DS126858.md]"));
-            Assert.IsTrue(markdown.Contains("for additional guidance on this issue"));
-        }
-
-        /// <summary>
         /// Test that rules without recommendations but with rule info still include help URI
         /// </summary>
         [TestMethod]

--- a/DevSkim-DotNet/Microsoft.DevSkim.Tests/SarifWriterTests.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.Tests/SarifWriterTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DevSkim.Tests
         /// Test that rules with recommendations properly include the recommendation in the SARIF Help field
         /// </summary>
         [TestMethod]
-        public void SarifWriter_RuleWithRecommendation_IncludesRecommendationInHelp()
+        public void When_rule_has_recommendation_then_sarif_help_text_matches_recommendation()
         {
             // Arrange
             const string expectedRecommendation = "Use a more secure hashing algorithm like SHA-256 instead of MD5.";
@@ -40,7 +40,7 @@ namespace Microsoft.DevSkim.Tests
         /// Test that rules without recommendations fall back to description in the SARIF Help field
         /// </summary>
         [TestMethod]
-        public void SarifWriter_RuleWithoutRecommendation_FallsBackToDescriptionInHelp()
+        public void When_rule_has_no_recommendation_then_sarif_help_text_falls_back_to_description()
         {
             // Arrange
             const string expectedDescription = "Test description for fallback";
@@ -65,7 +65,7 @@ namespace Microsoft.DevSkim.Tests
         /// Test that rules with recommendations and rule info include both in markdown help
         /// </summary>
         [TestMethod]
-        public void SarifWriter_RuleWithRecommendationAndRuleInfo_IncludesBothInMarkdown()
+        public void When_rule_has_recommendation_and_rule_info_then_markdown_includes_both()
         {
             // Arrange
             const string expectedRecommendation = "Use SHA-256 instead of MD5.";
@@ -99,7 +99,7 @@ namespace Microsoft.DevSkim.Tests
         /// Test that rules without recommendations but with rule info still include help URI
         /// </summary>
         [TestMethod]
-        public void SarifWriter_RuleWithoutRecommendationButWithRuleInfo_IncludesHelpUri()
+        public void When_rule_has_no_recommendation_but_has_rule_info_then_markdown_includes_help_uri()
         {
             // Arrange
             const string ruleInfo = "DS126858.md";
@@ -130,7 +130,7 @@ namespace Microsoft.DevSkim.Tests
         /// Test that rules with empty recommendation string behave like rules without recommendations
         /// </summary>
         [TestMethod]
-        public void SarifWriter_RuleWithEmptyRecommendation_FallsBackToDescription()
+        public void When_rule_has_empty_recommendation_then_sarif_help_text_falls_back_to_description()
         {
             // Arrange
             const string expectedDescription = "Test description for empty recommendation";
@@ -155,7 +155,7 @@ namespace Microsoft.DevSkim.Tests
         /// Test that rules with whitespace-only recommendation string result in empty help due to SARIF SDK serialization behavior
         /// </summary>
         [TestMethod]
-        public void SarifWriter_RuleWithWhitespaceRecommendation_ResultsInEmptyHelp()
+        public void When_rule_has_whitespace_only_recommendation_then_sarif_help_is_empty()
         {
             // Arrange
             const string expectedDescription = "Test description for whitespace recommendation";
@@ -193,7 +193,7 @@ namespace Microsoft.DevSkim.Tests
         /// Test that rules without recommendation and without description fall back to generic help message
         /// </summary>
         [TestMethod]
-        public void SarifWriter_RuleWithoutRecommendationAndDescription_FallsBackToGenericHelp()
+        public void When_rule_has_no_recommendation_and_no_description_then_sarif_help_contains_generic_message()
         {
             // Arrange
             const string ruleInfo = "DS126858.md";
@@ -220,7 +220,7 @@ namespace Microsoft.DevSkim.Tests
         /// Test that multiple rules with different recommendation states are handled correctly
         /// </summary>
         [TestMethod]
-        public void SarifWriter_MultipleRulesWithDifferentRecommendations_HandledCorrectly()
+        public void When_multiple_rules_have_different_recommendation_states_then_each_is_handled_correctly()
         {
             // Arrange
             var rule1 = CreateTestRule("TEST008", "Rule with recommendation", "Description 1", "Recommendation 1");
@@ -255,7 +255,7 @@ namespace Microsoft.DevSkim.Tests
         /// Test that markdown field is properly formatted when recommendation is present
         /// </summary>
         [TestMethod]
-        public void SarifWriter_RecommendationPresent_MarkdownFieldProperlyFormatted()
+        public void When_rule_has_recommendation_and_rule_info_then_markdown_is_properly_formatted()
         {
             // Arrange
             const string recommendation = "Use bcrypt for password hashing.";
@@ -285,7 +285,7 @@ namespace Microsoft.DevSkim.Tests
         /// Test that rule with only RuleInfo (no recommendation) has proper markdown
         /// </summary>
         [TestMethod]
-        public void SarifWriter_OnlyRuleInfo_MarkdownContainsHelpUri()
+        public void When_rule_has_only_rule_info_then_markdown_contains_help_uri()
         {
             // Arrange
             const string ruleInfo = "DS789012.md";

--- a/DevSkim-DotNet/Microsoft.DevSkim.Tests/SarifWriterTests.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.Tests/SarifWriterTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DevSkim.Tests
             sarifWriter.WriteIssue(issue);
             sarifWriter.FlushAndClose();
 
-            var sarifOutput = ParseSarifOutput(writer.ToString());
+            var sarifOutput = JObject.Parse(writer.ToString());
             var sarifRule = GetRuleFromSarif(sarifOutput, "TEST001");
             
             Assert.IsNotNull(sarifRule);
@@ -54,7 +54,7 @@ namespace Microsoft.DevSkim.Tests
             sarifWriter.WriteIssue(issue);
             sarifWriter.FlushAndClose();
 
-            var sarifOutput = ParseSarifOutput(writer.ToString());
+            var sarifOutput = JObject.Parse(writer.ToString());
             var sarifRule = GetRuleFromSarif(sarifOutput, "TEST002");
             
             Assert.IsNotNull(sarifRule);
@@ -80,7 +80,7 @@ namespace Microsoft.DevSkim.Tests
             sarifWriter.WriteIssue(issue);
             sarifWriter.FlushAndClose();
 
-            var sarifOutput = ParseSarifOutput(writer.ToString());
+            var sarifOutput = JObject.Parse(writer.ToString());
             var sarifRule = GetRuleFromSarif(sarifOutput, "TEST003");
             
             Assert.IsNotNull(sarifRule);
@@ -113,7 +113,7 @@ namespace Microsoft.DevSkim.Tests
             sarifWriter.WriteIssue(issue);
             sarifWriter.FlushAndClose();
 
-            var sarifOutput = ParseSarifOutput(writer.ToString());
+            var sarifOutput = JObject.Parse(writer.ToString());
             var sarifRule = GetRuleFromSarif(sarifOutput, "TEST004");
             
             Assert.IsNotNull(sarifRule);
@@ -144,7 +144,7 @@ namespace Microsoft.DevSkim.Tests
             sarifWriter.WriteIssue(issue);
             sarifWriter.FlushAndClose();
 
-            var sarifOutput = ParseSarifOutput(writer.ToString());
+            var sarifOutput = JObject.Parse(writer.ToString());
             var sarifRule = GetRuleFromSarif(sarifOutput, "TEST005");
             
             Assert.IsNotNull(sarifRule);
@@ -171,7 +171,7 @@ namespace Microsoft.DevSkim.Tests
             sarifWriter.FlushAndClose();
 
             var sarifJson = writer.ToString();
-            var sarifOutput = ParseSarifOutput(sarifJson);
+            var sarifOutput = JObject.Parse(sarifJson);
             var sarifRule = GetRuleFromSarif(sarifOutput, "TEST006");
             
             Assert.IsNotNull(sarifRule, $"sarifRule should not be null. SARIF output: {sarifJson}");
@@ -207,7 +207,7 @@ namespace Microsoft.DevSkim.Tests
             sarifWriter.WriteIssue(issue);
             sarifWriter.FlushAndClose();
 
-            var sarifOutput = ParseSarifOutput(writer.ToString());
+            var sarifOutput = JObject.Parse(writer.ToString());
             var sarifRule = GetRuleFromSarif(sarifOutput, "TEST007");
             
             Assert.IsNotNull(sarifRule);
@@ -236,7 +236,7 @@ namespace Microsoft.DevSkim.Tests
             sarifWriter.WriteIssue(issue2);
             sarifWriter.FlushAndClose();
 
-            var sarifOutput = ParseSarifOutput(writer.ToString());
+            var sarifOutput = JObject.Parse(writer.ToString());
             
             var sarifRule1 = GetRuleFromSarif(sarifOutput, "TEST008");
             var sarifRule2 = GetRuleFromSarif(sarifOutput, "TEST009");
@@ -270,7 +270,7 @@ namespace Microsoft.DevSkim.Tests
             sarifWriter.WriteIssue(issue);
             sarifWriter.FlushAndClose();
 
-            var sarifOutput = ParseSarifOutput(writer.ToString());
+            var sarifOutput = JObject.Parse(writer.ToString());
             var sarifRule = GetRuleFromSarif(sarifOutput, "TEST010");
             
             Assert.IsNotNull(sarifRule);
@@ -299,7 +299,7 @@ namespace Microsoft.DevSkim.Tests
             sarifWriter.WriteIssue(issue);
             sarifWriter.FlushAndClose();
 
-            var sarifOutput = ParseSarifOutput(writer.ToString());
+            var sarifOutput = JObject.Parse(writer.ToString());
             var sarifRule = GetRuleFromSarif(sarifOutput, "TEST011");
             
             Assert.IsNotNull(sarifRule);
@@ -351,11 +351,6 @@ namespace Microsoft.DevSkim.Tests
             );
 
             return new IssueRecord(filename, 0, textSample, issue, "csharp", null);
-        }
-
-        private JObject ParseSarifOutput(string sarifJson)
-        {
-            return JObject.Parse(sarifJson);
         }
 
         private JToken? GetRuleFromSarif(JObject sarifOutput, string ruleId)

--- a/DevSkim-DotNet/Microsoft.DevSkim.Tests/SarifWriterTests.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.Tests/SarifWriterTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.DevSkim.Tests
             
             // Markdown should still include help URI
             var markdown = sarifRule["help"]!["markdown"]!.ToString();
-            Assert.IsTrue(markdown.Contains($"Visit [{SarifWriter.baseHelpUri}DS126858.md]"));
+            Assert.IsTrue(markdown.Contains($"Visit [{SarifWriter.CreateHelpUri("DS126858.md")}]"));
         }
 
         /// <summary>
@@ -179,7 +179,7 @@ namespace Microsoft.DevSkim.Tests
             Assert.IsNotNull(sarifRule);
             
             var helpText = sarifRule!["help"]!["text"]!.ToString();
-            Assert.IsTrue(helpText.Contains($"Visit {SarifWriter.baseHelpUri}DS126858.md for guidance on this issue"));
+            Assert.IsTrue(helpText.Contains($"Visit {SarifWriter.CreateHelpUri("DS126858.md")} for guidance on this issue"));
         }
 
         /// <summary>
@@ -242,7 +242,7 @@ namespace Microsoft.DevSkim.Tests
             Assert.IsNotNull(sarifRule);
             
             var markdown = sarifRule!["help"]!["markdown"]!.ToString();
-            var expectedMarkdown = $"{recommendation} Visit [{SarifWriter.baseHelpUri}{ruleInfo}]({SarifWriter.baseHelpUri}{ruleInfo}) for additional guidance on this issue.";
+            var expectedMarkdown = $"{recommendation} Visit [{SarifWriter.CreateHelpUri(ruleInfo)}]({SarifWriter.CreateHelpUri(ruleInfo)}) for additional guidance on this issue.";
             
             Assert.AreEqual(expectedMarkdown, markdown);
         }
@@ -271,7 +271,7 @@ namespace Microsoft.DevSkim.Tests
             Assert.IsNotNull(sarifRule);
             
             var markdown = sarifRule!["help"]!["markdown"]!.ToString();
-            var expectedMarkdown = $"Visit [{SarifWriter.baseHelpUri}{ruleInfo}]({SarifWriter.baseHelpUri}{ruleInfo}) for additional guidance on this issue.";
+            var expectedMarkdown = $"Visit [{SarifWriter.CreateHelpUri(ruleInfo)}]({SarifWriter.CreateHelpUri(ruleInfo)}) for additional guidance on this issue.";
             
             Assert.AreEqual(expectedMarkdown, markdown);
         }

--- a/DevSkim-DotNet/Microsoft.DevSkim.Tests/SarifWriterTests.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.Tests/SarifWriterTests.cs
@@ -89,7 +89,8 @@ namespace Microsoft.DevSkim.Tests
             
             // Markdown should still include help URI
             var markdown = sarifRule["help"]!["markdown"]!.ToString();
-            var expectedMarkdown = $"Visit [{SarifWriter.CreateHelpUri("DS126858.md")}]({SarifWriter.CreateHelpUri("DS126858.md")}) for additional guidance on this issue.";
+            var helpUri = SarifWriter.CreateHelpUri("DS126858.md");
+            var expectedMarkdown = $"Visit [{helpUri}]({helpUri}) for additional guidance on this issue.";
             Assert.AreEqual(expectedMarkdown, markdown);
         }
 
@@ -244,7 +245,8 @@ namespace Microsoft.DevSkim.Tests
             Assert.IsNotNull(sarifRule);
             
             var markdown = sarifRule!["help"]!["markdown"]!.ToString();
-            var expectedMarkdown = $"{recommendation} Visit [{SarifWriter.CreateHelpUri(ruleInfo)}]({SarifWriter.CreateHelpUri(ruleInfo)}) for additional guidance on this issue.";
+            var helpUri = SarifWriter.CreateHelpUri(ruleInfo);
+            var expectedMarkdown = $"{recommendation} Visit [{helpUri}]({helpUri}) for additional guidance on this issue.";
             
             Assert.AreEqual(expectedMarkdown, markdown);
         }
@@ -273,7 +275,8 @@ namespace Microsoft.DevSkim.Tests
             Assert.IsNotNull(sarifRule);
             
             var markdown = sarifRule!["help"]!["markdown"]!.ToString();
-            var expectedMarkdown = $"Visit [{SarifWriter.CreateHelpUri(ruleInfo)}]({SarifWriter.CreateHelpUri(ruleInfo)}) for additional guidance on this issue.";
+            var helpUri = SarifWriter.CreateHelpUri(ruleInfo);
+            var expectedMarkdown = $"Visit [{helpUri}]({helpUri}) for additional guidance on this issue.";
             
             Assert.AreEqual(expectedMarkdown, markdown);
         }

--- a/DevSkim-DotNet/Microsoft.DevSkim.Tests/SarifWriterTests.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.Tests/SarifWriterTests.cs
@@ -322,16 +322,7 @@ namespace Microsoft.DevSkim.Tests
                 Recommendation = recommendation,
                 RuleInfo = ruleInfo,
                 Severity = Severity.Important,
-                Confidence = Confidence.High,
-                Patterns = new[]
-                {
-                    new SearchPattern
-                    {
-                        Pattern = "MD5",
-                        PatternType = PatternType.Regex,
-                        Scopes = new[] { PatternScope.All }
-                    }
-                }
+                Confidence = Confidence.High
             };
         }
 

--- a/DevSkim-DotNet/Microsoft.DevSkim.Tests/SarifWriterTests.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.Tests/SarifWriterTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.DevSkim.Tests
             
             // Markdown should still include help URI
             var markdown = sarifRule["help"]!["markdown"]!.ToString();
-            Assert.IsTrue(markdown.Contains("Visit [https://github.com/Microsoft/DevSkim/blob/main/guidance/DS126858.md]"));
+            Assert.IsTrue(markdown.Contains($"Visit [{SarifWriter.baseHelpUri}DS126858.md]"));
         }
 
         /// <summary>
@@ -179,7 +179,7 @@ namespace Microsoft.DevSkim.Tests
             Assert.IsNotNull(sarifRule);
             
             var helpText = sarifRule!["help"]!["text"]!.ToString();
-            Assert.IsTrue(helpText.Contains("Visit https://github.com/Microsoft/DevSkim/blob/main/guidance/DS126858.md for guidance on this issue"));
+            Assert.IsTrue(helpText.Contains($"Visit {SarifWriter.baseHelpUri}DS126858.md for guidance on this issue"));
         }
 
         /// <summary>
@@ -242,7 +242,7 @@ namespace Microsoft.DevSkim.Tests
             Assert.IsNotNull(sarifRule);
             
             var markdown = sarifRule!["help"]!["markdown"]!.ToString();
-            var expectedMarkdown = $"{recommendation} Visit [https://github.com/Microsoft/DevSkim/blob/main/guidance/{ruleInfo}](https://github.com/Microsoft/DevSkim/blob/main/guidance/{ruleInfo}) for additional guidance on this issue.";
+            var expectedMarkdown = $"{recommendation} Visit [{SarifWriter.baseHelpUri}{ruleInfo}]({SarifWriter.baseHelpUri}{ruleInfo}) for additional guidance on this issue.";
             
             Assert.AreEqual(expectedMarkdown, markdown);
         }
@@ -271,7 +271,7 @@ namespace Microsoft.DevSkim.Tests
             Assert.IsNotNull(sarifRule);
             
             var markdown = sarifRule!["help"]!["markdown"]!.ToString();
-            var expectedMarkdown = $"Visit [https://github.com/Microsoft/DevSkim/blob/main/guidance/{ruleInfo}](https://github.com/Microsoft/DevSkim/blob/main/guidance/{ruleInfo}) for additional guidance on this issue.";
+            var expectedMarkdown = $"Visit [{SarifWriter.baseHelpUri}{ruleInfo}]({SarifWriter.baseHelpUri}{ruleInfo}) for additional guidance on this issue.";
             
             Assert.AreEqual(expectedMarkdown, markdown);
         }

--- a/DevSkim-DotNet/Microsoft.DevSkim.Tests/SuppressionsTest.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim.Tests/SuppressionsTest.cs
@@ -270,7 +270,6 @@ namespace Microsoft.DevSkim.Tests
             File.Delete(outFileName);
 
             string basePath = Path.GetTempPath();
-            string oneUpPath = Directory.GetParent(basePath).FullName;
             using FileStream file = File.Open(tempFileName, FileMode.Create);
             file.Write(Encoding.UTF8.GetBytes(content));
             file.Close();

--- a/DevSkim-DotNet/Microsoft.DevSkim/DevSkimRuleProcessor.cs
+++ b/DevSkim-DotNet/Microsoft.DevSkim/DevSkimRuleProcessor.cs
@@ -122,9 +122,10 @@ namespace Microsoft.DevSkim
                     Regex regex = new Regex(pattern.Pattern, options);
                     return regex;
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     // failed to construct regex for fix
+                    // TODO: would need to refactor to be able to log here because the logger is being passed in the constructor but this method is static
                 }    
             }
 

--- a/DevSkim-VSCode-Plugin/client/package-lock.json
+++ b/DevSkim-VSCode-Plugin/client/package-lock.json
@@ -157,9 +157,10 @@
 			"dev": true
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -599,9 +600,9 @@
 			"dev": true
 		},
 		"brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"

--- a/DevSkim-VSCode-Plugin/package-lock.json
+++ b/DevSkim-VSCode-Plugin/package-lock.json
@@ -1729,9 +1729,9 @@
 			]
 		},
 		"node_modules/@vscode/vsce/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"version": "2.0.2",
+			"resolved": "https://twcsecurityassurance.pkgs.visualstudio.com/SecurityEngineering/_packaging/PublicRegistriesFeed/npm/registry/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha1-VPxTI3phPYVMe9N0Y6rRffhyFOc=",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2002,10 +2002,11 @@
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "1.1.12",
+			"resolved": "https://twcsecurityassurance.pkgs.visualstudio.com/SecurityEngineering/_packaging/PublicRegistriesFeed/npm/registry/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha1-q5tFRGblqMw6GHvqrVgEEqnFuEM=",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -3146,15 +3147,16 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-			"integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+			"version": "4.0.4",
+			"resolved": "https://twcsecurityassurance.pkgs.visualstudio.com/SecurityEngineering/_packaging/PublicRegistriesFeed/npm/registry/form-data/-/form-data-4.0.4.tgz",
+			"integrity": "sha1-eEzczgZpqdaOlNEaxO6pgIjt0sQ=",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
 				"mime-types": "^2.1.12"
 			},
 			"engines": {

--- a/DevSkim-VSCode-Plugin/package-lock.json
+++ b/DevSkim-VSCode-Plugin/package-lock.json
@@ -1730,8 +1730,8 @@
 		},
 		"node_modules/@vscode/vsce/node_modules/brace-expansion": {
 			"version": "2.0.2",
-			"resolved": "https://twcsecurityassurance.pkgs.visualstudio.com/SecurityEngineering/_packaging/PublicRegistriesFeed/npm/registry/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha1-VPxTI3phPYVMe9N0Y6rRffhyFOc=",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2003,8 +2003,8 @@
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.12",
-			"resolved": "https://twcsecurityassurance.pkgs.visualstudio.com/SecurityEngineering/_packaging/PublicRegistriesFeed/npm/registry/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha1-q5tFRGblqMw6GHvqrVgEEqnFuEM=",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3148,8 +3148,8 @@
 		},
 		"node_modules/form-data": {
 			"version": "4.0.4",
-			"resolved": "https://twcsecurityassurance.pkgs.visualstudio.com/SecurityEngineering/_packaging/PublicRegistriesFeed/npm/registry/form-data/-/form-data-4.0.4.tgz",
-			"integrity": "sha1-eEzczgZpqdaOlNEaxO6pgIjt0sQ=",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {


### PR DESCRIPTION
This pull request introduces several improvements and updates across the project, including bug fixes, dependency updates, enhancements to the `SarifWriter` logic, and the addition of comprehensive test cases. Below is a summary of the most important changes:

### Bug Fixes and Enhancements:
* Fixed an issue where the Sarif Markdown value failed to populate the rule's provided recommendation value. Updated the logic in `SarifWriter` to ensure recommendations, descriptions, and rule information are appropriately handled in SARIF output. (`DevSkim-DotNet/Microsoft.DevSkim.CLI/Writers/SarifWriter.cs`, [[1]](diffhunk://#diff-0e3b3ab35a2d319b372202ae32e389dbd4492307eaefa4096526bc9890af4708R204-R210) [[2]](diffhunk://#diff-0e3b3ab35a2d319b372202ae32e389dbd4492307eaefa4096526bc9890af4708R320-R369)

### Testing:
* Added extensive test cases for `SarifWriter` to validate the handling of recommendations, descriptions, and fallback logic in SARIF Help fields. These tests ensure robust behavior for various rule configurations. (`DevSkim-DotNet/Microsoft.DevSkim.Tests/SarifWriterTests.cs`, [DevSkim-DotNet/Microsoft.DevSkim.Tests/SarifWriterTests.csR1-R360](diffhunk://#diff-8ab8e4c3623bb3c155c3dac0ab76561049f67efbd0b85d351defd56bc2a163a6R1-R360))

### Dependency Updates:
* Updated the `brace-expansion` dependency in multiple `package-lock.json` files to address potential security or compatibility concerns:
  - Updated from version `1.1.11` to `1.1.12` in `DevSkim-VSCode-Plugin/client/package-lock.json`. [[1]](diffhunk://#diff-2776a76f94194d8912e08665f02ddf0c6651cd6417e26ff6a8564dd5c5c19a5cL160-R163) [[2]](diffhunk://#diff-2776a76f94194d8912e08665f02ddf0c6651cd6417e26ff6a8564dd5c5c19a5cL602-R605)
  - Updated from version `2.0.1` to `2.0.2` in `DevSkim-VSCode-Plugin/package-lock.json`.

### Documentation:
* Updated the `Changelog.md` file to document the changes introduced in version `1.0.63`, including the bug fix, dependency updates, and new test cases.