### PR TITLE
Remove VS Code plugin build step from pipelines

### DIFF
--- a/Pipelines/vscode/devskim-vscode-pr.yml
+++ b/Pipelines/vscode/devskim-vscode-pr.yml
@@ -49,12 +49,6 @@ extends:
           inputs:
             packageType: 'sdk'
             version: '9.0.x'
-        - task: Npm@1
-          displayName: Build VS Code Plugin
-          inputs:
-            command: 'custom'
-            workingDir: 'DevSkim-VSCode-Plugin/'     
-            customCommand: 'run build'
         - template: nbgv-set-version-steps.yml@templates
         - task: PowerShell@2
           displayName: Mkdir for Manifests and Packages

--- a/Pipelines/vscode/devskim-vscode-release.yml
+++ b/Pipelines/vscode/devskim-vscode-release.yml
@@ -48,12 +48,6 @@ extends:
           inputs:
             packageType: 'sdk'
             version: '9.0.x'
-        - task: Npm@1
-          displayName: Build VS Code Plugin
-          inputs:
-            command: 'custom'
-            workingDir: 'DevSkim-VSCode-Plugin/'     
-            customCommand: 'run build'
         - template: nbgv-set-version-steps.yml@templates
         - task: PowerShell@2
           displayName: Mkdir for Manifests and Packages


### PR DESCRIPTION
Eliminated the Npm build task for the VS Code plugin from both PR and release pipeline YAML files - the pipeline-pack step should be sufficient to create the extension file and performs the required steps to build properly in pipeline specficially.