### PR TITLE
Update tmp package to version 0.2.5

### DIFF
--- a/DevSkim-VSCode-Plugin/package-lock.json
+++ b/DevSkim-VSCode-Plugin/package-lock.json
@@ -5557,9 +5557,9 @@
 			}
 		},
 		"node_modules/tmp": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-			"integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+			"integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {


### PR DESCRIPTION
Bumped the tmp dependency from 0.2.3 to 0.2.5 in package-lock.json to include the latest fixes and improvements.