### PR TITLE
Use AzureArtifacts registry for vsce install

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,6 @@
 	"typescript.tsc.autoDetect": "off",
 	"typescript.preferences.quoteStyle": "single",
 	"editor.codeActionsOnSave": {
-		"source.fixAll.eslint": true
+		"source.fixAll.eslint": "explicit"
 	}
 }

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.77] - 2026-03-26
+### Pipeline
+Try to fix VS Code Publishing Pipeline issue with VSCE tool install
+
 ## [1.0.76] - 2026-02-12
 ### Fix
 - Fixed DS126858 rule (Weak/Broken Hash Algorithm) false positive when MD5 is explicitly disabled via flags like `--nomd5`, `nomd5`, `no-md5`, `no_md5`, or `disable_md5_check`

--- a/Pipelines/vscode/devskim-vscode-release.yml
+++ b/Pipelines/vscode/devskim-vscode-release.yml
@@ -158,7 +158,7 @@ extends:
         # Install dependencies and VS Code Extension Manager (vsce >= v2.26.1 needed)
         - script: |
               cd $(Build.StagingDirectory)
-              npm install -g @vscode/vsce
+              npm install -g @vscode/vsce --registry https://pkgs.dev.azure.com/artifacts-public/23934c1b-a3b5-4b70-9dd3-d1bef4cc72a0/_packaging/AzureArtifacts/npm/registry/
               npm install
           displayName: "Install vsce and dependencies"
 


### PR DESCRIPTION
Update CI pipeline to install @vscode/vsce using the Azure Artifacts npm registry via the --registry flag. This ensures the vsce package is resolved from the organization's feed during the release pipeline.