### PR TITLE
Update VSCode extension deps and settings

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.82] - 2026-05-12
+### Dependencies
+- Update dependencies for VS Code Extension
+
 ## [1.0.81] - 2026-04-16
 ### Pipeline
 - Updates to fix release pipeline for VSCode extension.

--- a/DevSkim-VSCode-Plugin/.vscode/settings.json
+++ b/DevSkim-VSCode-Plugin/.vscode/settings.json
@@ -3,6 +3,6 @@
 	"typescript.tsc.autoDetect": "off",
 	"typescript.preferences.quoteStyle": "single",
 	"editor.codeActionsOnSave": {
-		"source.fixAll.eslint": true
+		"source.fixAll.eslint": "explicit"
 	}
 }

--- a/DevSkim-VSCode-Plugin/package-lock.json
+++ b/DevSkim-VSCode-Plugin/package-lock.json
@@ -13,7 +13,7 @@
 				"@types/node": "^14.x",
 				"@typescript-eslint/eslint-plugin": "^8.0.0",
 				"@typescript-eslint/parser": "^8.0.0",
-				"@vscode/vsce": "^3.7.1",
+				"@vscode/vsce": "^3.9.1",
 				"esbuild": "^0.25.2",
 				"eslint": "^9.0.0",
 				"nerdbank-gitversioning": "^3.4.255",
@@ -1583,9 +1583,9 @@
 			}
 		},
 		"node_modules/@vscode/vsce": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.7.1.tgz",
-			"integrity": "sha512-OTm2XdMt2YkpSn2Nx7z2EJtSuhRHsTPYsSK59hr3v8jRArK+2UEoju4Jumn1CmpgoBLGI6ReHLJ/czYltNUW3g==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.9.1.tgz",
+			"integrity": "sha512-MPn5p+DoudI+3GfJSpAZZraE1lgLv0LcwbH3+xy7RgEhty3UIkmUMUA+5jPTDaxXae00AnX5u77FxGM8FhfKKA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1616,7 +1616,7 @@
 				"typed-rest-client": "^1.8.4",
 				"url-join": "^4.0.1",
 				"xml2js": "^0.5.0",
-				"yauzl": "^2.3.1",
+				"yauzl": "^3.2.1",
 				"yazl": "^2.2.2"
 			},
 			"bin": {
@@ -2976,9 +2976,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -2999,16 +2999,6 @@
 			"dev": true,
 			"dependencies": {
 				"reusify": "^1.0.4"
-			}
-		},
-		"node_modules/fd-slicer": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"pend": "~1.2.0"
 			}
 		},
 		"node_modules/file-entry-cache": {
@@ -5825,14 +5815,17 @@
 			"license": "ISC"
 		},
 		"node_modules/yauzl": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.0.tgz",
+			"integrity": "sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"buffer-crc32": "~0.2.3",
-				"fd-slicer": "~1.1.0"
+				"pend": "~1.2.0"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/yazl": {

--- a/DevSkim-VSCode-Plugin/package.json
+++ b/DevSkim-VSCode-Plugin/package.json
@@ -324,7 +324,7 @@
 		"@types/node": "^14.x",
 		"@typescript-eslint/eslint-plugin": "^8.0.0",
 		"@typescript-eslint/parser": "^8.0.0",
-		"@vscode/vsce": "^3.7.1",
+		"@vscode/vsce": "^3.9.1",
 		"esbuild": "^0.25.2",
 		"eslint": "^9.0.0",
 		"nerdbank-gitversioning": "^3.4.255",


### PR DESCRIPTION
Bump extension dev dependency (@vscode/vsce) and update related lockfile. Change .vscode setting for editor.codeActionsOnSave to use "source.fixAll.eslint": "explicit". Add Changelog entry for 1.0.82 noting dependency updates for the VS Code extension.