### PR TITLE
Consolidate Dependabot updates into a single grouped pull request

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,16 +32,23 @@ DevSkim is a framework of IDE extensions and language analyzers that provide inl
 - This project uses **squash merges**
 - PR gate checks verify `Changelog.md` is updated
 - Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
-- Use semantic versioning: `[MAJOR.MINOR.PATCH]`
+- Version headings are `[MAJOR.MINOR.PATCH]` and must match the version the build actually produces
+
+**Versioning**: this repo versions with [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning). `version.json` pins `MAJOR.MINOR` (currently `1.0`) and the patch number is the **git height**, which is the commit count since `version.json` last changed. Do **not** guess it by incrementing the previous changelog entry: an open PR's height shifts every time another PR merges ahead of it, and blindly incrementing bakes that drift in permanently.
 
 **When making changes**:
 1. Add a new entry at the top of `Changelog.md` (after the header)
-2. Use the **next patch version** (increment last number by 1)
+2. Determine the version by asking Nerdbank.GitVersioning what this commit produces, rather than incrementing the previous entry:
+   ```bash
+   dotnet tool install --global nbgv   # once
+   nbgv get-version -v SimpleVersion   # e.g. 1.0.95
+   ```
+   Run this **after** committing your change and with your branch rebased on the latest `main`, since the height includes your own commit. If your PR sits open while other PRs merge, re-run it and update the heading before merging.
 3. Use today's date in YYYY-MM-DD format
 4. Group changes by type: `### Fix`, `### Added`, `### Changed`, `### Dependencies`, `### Pipeline`, etc.
 5. Write clear, actionable descriptions
 
-**Example**:
+**Example** (assuming `nbgv get-version -v SimpleVersion` reported `1.0.72`):
 ```markdown
 ## [1.0.72] - 2026-02-04
 ### Added
@@ -50,6 +57,8 @@ DevSkim is a framework of IDE extensions and language analyzers that provide inl
 ### Changed
 - Updated build documentation
 ```
+
+**Exception**: the gate ([`tarides/changelog-check-action`](https://github.com/tarides/changelog-check-action)) is skipped on PRs carrying the `no changelog` label. That is reserved for changes that are not user-visible, and Dependabot applies it automatically via `.github/dependabot.yml`. Do not use it to avoid writing an entry for a real change.
 
 ## Building and Testing
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,100 @@
+# Dependabot configuration for DevSkim.
+#
+# Goal: one pull request to review and merge instead of one per dependency.
+#
+# * Version updates for every ecosystem (npm, NuGet, GitHub Actions) are assigned to
+#   the `all-dependencies` multi-ecosystem group, so Dependabot consolidates them --
+#   across every directory it monitors -- into a single weekly pull request.
+# * Security updates cannot join a multi-ecosystem group, so each ecosystem also
+#   declares a `*-security-updates` group. Advisory-driven bumps then arrive as one
+#   grouped pull request per ecosystem instead of one per advisory.
+# * `open-pull-requests-limit: 1` caps each ecosystem at a single open version-update
+#   pull request, so nothing slips out of the grouping.
+# * The `no changelog` label lets the required "Check Changelog Action" gate pass on
+#   bot pull requests, which do not touch Changelog.md.
+#
+# Reference:
+# https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
+
+version: 2
+
+multi-ecosystem-groups:
+  all-dependencies:
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    labels:
+      - "dependencies"
+      - "no changelog"
+
+updates:
+  # VS Code plugin: extension host and language client packages.
+  - package-ecosystem: "npm"
+    directories:
+      - "/DevSkim-VSCode-Plugin"
+      - "/DevSkim-VSCode-Plugin/client"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    multi-ecosystem-group: "all-dependencies"
+    patterns:
+      - "*"
+    open-pull-requests-limit: 1
+    labels:
+      - "dependencies"
+      - "no changelog"
+      - "javascript"
+    groups:
+      npm-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # .NET: library, CLI, language server, and Visual Studio extension projects
+  # discovered through Microsoft.DevSkim.sln.
+  - package-ecosystem: "nuget"
+    directory: "/DevSkim-DotNet"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    multi-ecosystem-group: "all-dependencies"
+    patterns:
+      - "*"
+    open-pull-requests-limit: 1
+    labels:
+      - "dependencies"
+      - "no changelog"
+      - ".NET"
+    groups:
+      nuget-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # GitHub Actions used by the workflows in .github/workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    multi-ecosystem-group: "all-dependencies"
+    patterns:
+      - "*"
+    open-pull-requests-limit: 1
+    labels:
+      - "dependencies"
+      - "no changelog"
+      - "pipeline"
+    groups:
+      github-actions-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.95] - 2026-07-31
+### Pipeline
+- Added `.github/dependabot.yml` so Dependabot consolidates npm, NuGet, and GitHub Actions version updates into a single weekly pull request via a multi-ecosystem group, groups security updates per ecosystem into one pull request each, and labels its pull requests `no changelog` so the changelog gate passes.
+
+### Documentation
+- Corrected the changelog guidance in `.github/copilot-instructions.md` to derive the version heading from Nerdbank.GitVersioning (`nbgv get-version`) instead of incrementing the previous entry, which had let the changelog headings drift behind the versions actually built, and documented the `no changelog` label as the gate's escape hatch.
+
 ## [1.0.87] - 2026-07-15
 ### Pipeline
 - Updated the CLI release pipeline to use the .NET 10 SDK when restoring, building, packaging, and releasing .NET 10 targets.


### PR DESCRIPTION
## Why

The repo has no `dependabot.yml`, so Dependabot falls back to default behavior: one pull request per vulnerable dependency. That is why there is currently a backlog of separate npm security PRs (#764 through #769), each needing its own review and merge. On top of that, every one of those PRs fails the required "Check Changelog Action" gate, because bot PRs never touch `Changelog.md`.

## What this does

Adds `.github/dependabot.yml` that rolls dependency maintenance into as few PRs as possible:

- **One PR for all version updates.** npm, NuGet, and GitHub Actions are all assigned to a single `all-dependencies` multi-ecosystem group, so Dependabot consolidates every available update, across every monitored directory, into one weekly pull request instead of one per dependency.
- **One security PR per ecosystem.** Multi-ecosystem groups only cover version updates, so each ecosystem additionally declares a `*-security-updates` group with `patterns: ["*"]`. Advisory-driven bumps then arrive as a single grouped PR per ecosystem rather than one per advisory.
- **`open-pull-requests-limit: 1`** per ecosystem as a hard cap, so nothing escapes the grouping even if a dependency somehow falls outside a group.
- **Labels** `dependencies`, `no changelog`, plus `javascript` / `.NET` / `pipeline`. The `no changelog` label already exists in this repo and is the documented skip label for `tarides/changelog-check-action`, so grouped dependency PRs now pass the changelog gate instead of always failing it.

Directories covered: `/DevSkim-VSCode-Plugin` and `/DevSkim-VSCode-Plugin/client` for npm, `/DevSkim-DotNet` (projects discovered through `Microsoft.DevSkim.sln`) for NuGet, and `/` for GitHub Actions.

## Also: fixes the changelog versioning guidance

While writing the changelog entry for this PR I picked `1.0.88` by following `.github/copilot-instructions.md`, which says to take "the next patch version (increment last number by 1)". That turned out to be a version that had **already shipped**.

The real version is `1.0.<git height>` from Nerdbank.GitVersioning, so incrementing the previous changelog entry is only correct when no other PR merges in between. It has not been correct for a while:

| Commit | Version actually built | Changelog heading |
| --- | --- | --- |
| `da7c777` (#753) | 1.0.88 | `[1.0.85]` |
| `17706a8` (#755) | 1.0.89 | `[1.0.86]` |
| `fb2d676` (#763) | 1.0.90 | `[1.0.87]` |

Because each entry increments from the previous (already wrong) one, the drift is permanent and grows. So this PR also updates `.github/copilot-instructions.md` to derive the heading from `nbgv get-version -v SimpleVersion` and to re-check it if the PR sits open while others merge. It also documents the `no changelog` label as the gate's escape hatch, which is what the Dependabot config now relies on.

This PR's entry is `[1.0.95]`, confirmed via `nbgv get-version` against the branch head (`main` is currently at `1.0.94`). **If another PR merges before this one, that heading needs a bump.**

## Notes for reviewers

- Dependabot cannot merge different ecosystems into one PR through the ordinary `groups` key, which is why this uses the newer top-level `multi-ecosystem-groups` option. The config was validated against the published Dependabot v2 JSON schema, and the `multi-ecosystem-group` + `groups: applies-to: security-updates` combination is confirmed working in production configs such as `shakacode/react_on_rails` and `dfinity/internet-identity`.
- This also turns on **version** updates, which were previously off since there was no config. Expect the first grouped PR to be large, since it will carry every outdated dependency at once.
- `nuget.config` clears nuget.org in favor of a private Azure DevOps feed. If the .NET half of the group reports resolution errors in the Dependabot logs, that is the cause, and it would need a `registries` entry with credentials to fix. npm and GitHub Actions are unaffected.
- Schedule is weekly, Mondays at 06:00 UTC. Easy to switch to `monthly` if weekly still feels noisy.
