### PR TITLE
Fix VS Code release publish failing with npm E401

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.97] - 2026-08-11
+### Pipeline
+- Fixed the VS Code extension release pipeline failing at the publish step with `npm error code E401`. The step ran `npx @vscode/vsce`, and because the argument is a package name rather than a bin name, npx cannot short circuit to the copy installed by the preceding `npm install -g @vscode/vsce` step and always fetches the package manifest from the npm registry, which is not authenticated inside the `AzureCLI@2` task. The step now invokes the globally installed `vsce.cmd` by its full path, so publishing needs no registry access, and fails with an explicit message if the binary is missing.
+- Removed the `npm_config_registry` environment variable from the publish step. It was only there to make the `npx` fetch resolve, is redundant with the `.npmrc` copied into the staging directory, and does not affect where the extension is published - `vsce publish` uploads to the Visual Studio Marketplace, not to an npm registry.
+
 ## [1.0.96] - 2026-08-03
 ### Dependencies
 - Consolidated the open Dependabot pull requests (#765, #766, #767, #768, #769) into a single update for the VS Code extension: `linkify-it` 5.0.1 to 5.0.2, `fast-uri` 3.1.2 to 3.1.4, `undici` 7.24.6 to 7.29.0, and `brace-expansion` 1.1.14 to 1.1.16 and 5.0.5 to 5.0.8.

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Pipeline
 - Fixed the VS Code extension release pipeline failing at the publish step with `npm error code E401`. The step ran `npx @vscode/vsce`, and because the argument is a package name rather than a bin name, npx cannot short circuit to the copy installed by the preceding `npm install -g @vscode/vsce` step and always fetches the package manifest from the npm registry, which is not authenticated inside the `AzureCLI@2` task. The step now invokes the globally installed `vsce.cmd` by its full path, so publishing needs no registry access, and fails with an explicit message if the binary is missing.
 - Removed the `npm_config_registry` environment variable from the publish step. It was only there to make the `npx` fetch resolve, is redundant with the `.npmrc` copied into the staging directory, and does not affect where the extension is published - `vsce publish` uploads to the Visual Studio Marketplace, not to an npm registry.
+- Hardened the VS Code publish step against an unexpected artifact count. It previously passed a `Resolve-Path` result straight to `--packagePath`, which yields `$null` when signing produced no `.vsix` and an array that splats into multiple arguments when it produced more than one. The step now resolves the artifact explicitly and fails with a clear message unless exactly one is present.
 
 ## [1.0.96] - 2026-08-03
 ### Dependencies

--- a/Pipelines/vscode/devskim-vscode-release.yml
+++ b/Pipelines/vscode/devskim-vscode-release.yml
@@ -183,11 +183,20 @@ extends:
             scriptLocation: 'inlineScript'
             workingDirectory: '$(Build.StagingDirectory)'
             inlineScript: |
-                $packPath = Resolve-Path $env:BUILD_STAGINGDIRECTORY\*.vsix
+                # Fail fast if signing/staging did not produce exactly one artifact, rather than
+                # passing a null or multi-element Resolve-Path result to --packagePath.
+                $vsixFiles = @(Get-ChildItem -Path $env:BUILD_STAGINGDIRECTORY -Filter '*.vsix' -File)
+                if ($vsixFiles.Count -ne 1)
+                {
+                    throw "Expected exactly one .vsix in $env:BUILD_STAGINGDIRECTORY, found $($vsixFiles.Count)"
+                }
+                $packPath = $vsixFiles[0].FullName
                 # Invoke the vsce installed globally in the previous step by its full path.
                 # `npx @vscode/vsce` cannot be used here: npx only short circuits to an already
                 # installed binary when the argument matches a bin name, so a package name always
                 # forces a manifest fetch from the npm registry, which fails with E401 in this task.
+                # On Windows npm's global bin directory is the global prefix itself, so `npm prefix -g`
+                # locates the shim (`npm bin` was removed in npm v9 and is not an option).
                 $vsce = Join-Path (npm prefix -g) 'vsce.cmd'
                 if (-not (Test-Path $vsce))
                 {

--- a/Pipelines/vscode/devskim-vscode-release.yml
+++ b/Pipelines/vscode/devskim-vscode-release.yml
@@ -184,18 +184,29 @@ extends:
             workingDirectory: '$(Build.StagingDirectory)'
             inlineScript: |
                 $packPath = Resolve-Path $env:BUILD_STAGINGDIRECTORY\*.vsix
+                # Invoke the vsce installed globally in the previous step by its full path.
+                # `npx @vscode/vsce` cannot be used here: npx only short circuits to an already
+                # installed binary when the argument matches a bin name, so a package name always
+                # forces a manifest fetch from the npm registry, which fails with E401 in this task.
+                $vsce = Join-Path (npm prefix -g) 'vsce.cmd'
+                if (-not (Test-Path $vsce))
+                {
+                    throw "vsce was not found at $vsce - check the 'Install vsce and dependencies' step"
+                }
                 if ("$(ReleaseVersion)".Contains("-"))
                 {
                     echo "Publishing as --pre-release = $(ReleaseVersion)"
-                    npx @vscode/vsce publish --packagePath $packPath --pre-release --azure-credential
+                    & $vsce publish --packagePath $packPath --pre-release --azure-credential
                 }
                 else
                 {
                     echo "Publishing as official release = $(ReleaseVersion)"
-                    npx @vscode/vsce publish --packagePath $packPath --azure-credential
+                    & $vsce publish --packagePath $packPath --azure-credential
                 }
-          env:
-            npm_config_registry: "https://pkgs.dev.azure.com/microsoft-sdl/General/_packaging/PublicRegistriesFeed/npm/registry/"
+                if ($LASTEXITCODE -ne 0)
+                {
+                    throw "vsce publish failed with exit code $LASTEXITCODE"
+                }
 
       - job: gitHubReleaseJob
         # Based on Documentation: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/releasepipelines/releaseworkflows/releasejob?tabs=standardreleasejob


### PR DESCRIPTION
## Why

The `DevSkim-VSCode-Release` pipeline has been unable to publish for several runs. The `Publishing with Managed Identity` step fails immediately after printing the version:

```
Publishing as official release = 1.0.84
npm error code E401
npm error Unable to authenticate, your authentication token seems to be invalid.
```

The suspicion was that `npm_config_registry` pointing at the internal Azure Artifacts feed was sending the extension to the wrong place. That is not what is happening. `vsce publish` uploads to the Visual Studio Marketplace over its own API, authenticated by `--azure-credential` using the AAD token from the task's `az login`. No npm registry is ever a publish target. The registry setting only controls where npm and npx *download* packages from, so it was never going to redirect the release.

## Root cause

The failure is `npx @vscode/vsce`, introduced in #742 when the bare `vsce` command was not resolvable on the agent's `PATH`.

npx only short circuits to an already-installed binary when its first argument matches a **bin name**. From `libnpmexec/lib/index.js`:

```js
} else if (globalPath && await fileExists(`${globalBin}/${args[0]}`)) {
  binPaths.push(globalBin)
  return await run()   // no registry call
}
packages.push(args[0])  // falls through -> pacote.manifest() -> registry
```

`@vscode/vsce` is a package name, so npx checks for `${globalBin}/@vscode/vsce`, which does not exist because the bin is named `vsce`. It falls through to a `pacote.manifest()` call. `npm_config_registry` (added in #743 to get that fetch working) aimed it at the authenticated feed, where the publish task has no valid npm credential, producing E401. The `npm install -g @vscode/vsce` from the preceding step was never consulted at all.

This reproduces exactly. With a fake global prefix containing a `vsce` shim and the registry pointed at the feed:

| invocation | result |
| --- | --- |
| `npx vsce publish ...` | runs the pre-installed binary, exit 0, no network access |
| `npx @vscode/vsce publish ...` | `npm error code E401 / Unable to authenticate...`, byte-identical to the pipeline log |

## Approach

Skip npx entirely and invoke the binary that the previous step already installed, by its full path:

```powershell
$vsce = Join-Path (npm prefix -g) 'vsce.cmd'
if (-not (Test-Path $vsce)) { throw "vsce was not found at $vsce - ..." }
& $vsce publish --packagePath $packPath --azure-credential
if ($LASTEXITCODE -ne 0) { throw "vsce publish failed with exit code $LASTEXITCODE" }
```

Publishing now needs no npm registry access whatsoever, which removes the whole class of feed-auth failures from this step. `npm prefix -g` also sidesteps the original #742 problem, since it resolves the global prefix directly rather than relying on it being on `PATH`.

The step also no longer passes a raw `Resolve-Path` result to `--packagePath`. That returns `$null` when signing produced no `.vsix` (the error is non-terminating, so the script would have carried on and published nothing) and an array that splats into multiple native arguments when it produced more than one. It now enumerates the artifacts and throws unless exactly one is present, so a failed sign or move step is attributed correctly instead of surfacing as a confusing vsce error.

## Notes for reviewers

- **Why the full path instead of just `npx vsce`.** Changing the argument to the bin name would also fix the E401, but if the global install were ever missing, npx would silently fall back to installing the deprecated legacy `vsce` package from the registry. That package tops out at 2.15.0 and predates `--azure-credential`, which would fail in a much more confusing way. The explicit path fails loudly instead.
- **Why `npm prefix -g` and not `npm bin -g`.** `npm bin` was removed in npm v9 and exits 1 with `Unknown command: "bin"` on the npm the agents ship. This pool is pinned to `os: windows`, where npm treats the global prefix as the global bin directory (`globalBin` returns `globalPrefix` unchanged on win32), so the prefix is the correct place to look for the shim. There is a comment in the YAML recording this.
- **Removing `npm_config_registry` does not loosen package sourcing.** It is dead once npx is gone, and `.npmrc.pipeline` is already copied into `$(Build.StagingDirectory)`, which is the step's `workingDirectory`, so the same feed stays pinned for anything else that shells out to npm.
- **Left alone:** the bare `npm install` at the end of the `Install vsce and dependencies` step is a no-op, since `$(Build.StagingDirectory)` has no `package.json`. It is unrelated to this failure so I did not touch it.

## Validation

The pipeline YAML parses, and the inline PowerShell parses cleanly via `[System.Management.Automation.Language.Parser]::ParseInput`. The artifact guard was exercised against staging directories holding 0, 1, and 2 `.vsix` files: one yields a plain string path, zero and two both throw with the count. `nuget.config` and `.npmrc.pipeline` are untouched.

Rebased onto `main` after #773 landed. That PR also claimed `1.0.96`, so the changelog entry here moves to `1.0.97`, which is the git height at `main` (96) plus this squash-merged commit.
