### PR TITLE
Consolidate open Dependabot updates into one dependency bump

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.96] - 2026-08-03
+### Dependencies
+- Consolidated the open Dependabot pull requests (#765, #766, #767, #768, #769) into a single update for the VS Code extension: `linkify-it` 5.0.1 to 5.0.2, `fast-uri` 3.1.2 to 3.1.4, `undici` 7.24.6 to 7.29.0, and `brace-expansion` 1.1.14 to 1.1.16 and 5.0.5 to 5.0.8.
+- Bumped `vscode-languageclient` from 7.0.0 to 10.1.0 in the extension client, which pulls `vscode-languageserver-protocol` up to 3.18.2 and replaces the transitive `minimatch` 3.1.5 chain with 10.2.5.
+- Bumped `@types/vscode` from 1.77.0 to 1.91.0 to match the new minimum VS Code version.
+- Bumped `typescript` from 4.9.5 to 5.9.3; the `vscode-languageclient` 10 type declarations use the `NoInfer` utility type, which requires TypeScript 5.4 or newer.
+- Pinned `brace-expansion` to 1.1.16 and 5.0.8 and `minimatch` to 10.2.5 rather than the 1.1.18, 5.0.9, and 10.2.6 that Dependabot had selected. Those three releases have since been removed from the npm registry, so the packages could no longer be restored and the build failed with a 404 while fetching them.
+
+### Changed
+- Raised the minimum VS Code version supported by the extension from 1.63 to 1.91, which `vscode-languageclient` 10 requires.
+- Migrated `client/extension.ts` to the `vscode-languageclient` 8+ client lifecycle: `LanguageClient.start()` returns a promise instead of a disposable and `onReady()` no longer exists, so notification handlers are now registered before the client starts and the client is disposed through the extension context.
+- Switched the VS Code extension TypeScript projects to `node16` module resolution, which `vscode-languageclient` 10 requires because it declares its entry points only through `exports`.
+
 ## [1.0.95] - 2026-07-31
 ### Pipeline
 - Added `.github/dependabot.yml` so Dependabot consolidates npm, NuGet, and GitHub Actions version updates into a single weekly pull request via a multi-ecosystem group, groups security updates per ecosystem into one pull request each, and labels its pull requests `no changelog` so the changelog gate passes.

--- a/DevSkim-VSCode-Plugin/client/extension.ts
+++ b/DevSkim-VSCode-Plugin/client/extension.ts
@@ -113,19 +113,21 @@ export function activate(context: ExtensionContext) {
 				clientOptions
 			);
 
-			 // Start the client. This will also launch the server
 			client.registerProposedFeatures();
-			const disposable = client.start();
-			
-			client.onReady().then(() => 
+
+			// Notification handlers must be registered before the client starts so no
+			// message sent during initialization is missed.
+			client.onNotification(getCodeFixMapping(), (mapping: CodeFixMapping) =>
+			{
+				fixer.ensureMapHasMappings(mapping);
+			});
+			client.onNotification(getFileVersion(), (fileversion: FileVersion) =>{
+				fixer.removeFindingsForOtherVersions(fileversion);
+			});
+
+			// Start the client. This will also launch the server
+			client.start().then(() =>
 				{
-					client.onNotification(getCodeFixMapping(), (mapping: CodeFixMapping) => 
-					{
-						fixer.ensureMapHasMappings(mapping);
-					});
-					client.onNotification(getFileVersion(), (fileversion: FileVersion) =>{
-						fixer.removeFindingsForOtherVersions(fileversion);
-					});
 					client.sendNotification(DidChangeConfigurationNotification.type, { settings: ""});
 				}
 			);
@@ -140,7 +142,7 @@ export function activate(context: ExtensionContext) {
 			});
 
 			// For disposal of the client
-			context.subscriptions.push(disposable);
+			context.subscriptions.push(client);
 		}
 	});
 }

--- a/DevSkim-VSCode-Plugin/client/package-lock.json
+++ b/DevSkim-VSCode-Plugin/client/package-lock.json
@@ -9,20 +9,20 @@
 			"version": "0.0.0-placeholder",
 			"license": "MIT",
 			"dependencies": {
-				"vscode-languageclient": "^7.0.0"
+				"vscode-languageclient": "^10.1.0"
 			},
 			"devDependencies": {
-				"@types/vscode": "^1.63.0",
+				"@types/vscode": "^1.91.0",
 				"@vscode/test-electron": "^2.5.2"
 			},
 			"engines": {
-				"vscode": "^1.63.0"
+				"vscode": "^1.91.0"
 			}
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.77.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.77.0.tgz",
-			"integrity": "sha512-MWFN5R7a33n8eJZJmdVlifjig3LWUNRrPeO1xemIcZ0ae0TEQuRc7G2xV0LUX78RZFECY1plYBn+dP/Acc3L0Q==",
+			"version": "1.91.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.91.0.tgz",
+			"integrity": "sha512-PgPr+bUODjG3y+ozWUCyzttqR9EHny9sPAfJagddQjDwdtf66y2sDKJMnFZRuzBA2YtBGASqJGPil8VDUPvO6A==",
 			"dev": true
 		},
 		"node_modules/@vscode/test-electron": {
@@ -66,18 +66,22 @@
 			}
 		},
 		"node_modules/balanced-match": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-			"license": "MIT",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
 			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/chalk": {
@@ -121,11 +125,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"node_modules/core-util-is": {
 			"version": "1.0.3",
@@ -314,15 +313,17 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-			"license": "ISC",
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
 			"dependencies": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "^5.0.8"
 			},
 			"engines": {
-				"node": "*"
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/ms": {
@@ -427,10 +428,9 @@
 			"license": "MIT"
 		},
 		"node_modules/semver": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-			"license": "ISC",
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -523,46 +523,52 @@
 			"license": "MIT"
 		},
 		"node_modules/vscode-jsonrpc": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-			"integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
+			"integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
 			"engines": {
-				"node": ">=8.0.0 || >=10.0.0"
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/vscode-languageclient": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
-			"integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-10.1.0.tgz",
+			"integrity": "sha512-XXRx6lqVitQy/oOLr9MfNYRG+MbQkhXkDaxbQMiKxEm8zZNfheRFUKNb8UYNh2stn9btl2wQM5wZFJjJvoc+jA==",
 			"dependencies": {
-				"minimatch": "^3.0.4",
-				"semver": "^7.3.4",
-				"vscode-languageserver-protocol": "3.16.0"
+				"minimatch": "^10.2.5",
+				"semver": "^7.8.1",
+				"vscode-languageserver-protocol": "3.18.2",
+				"vscode-languageserver-textdocument": "1.0.13"
 			},
 			"engines": {
-				"vscode": "^1.52.0"
+				"vscode": "^1.91.0"
 			}
 		},
 		"node_modules/vscode-languageserver-protocol": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-			"integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+			"version": "3.18.2",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
+			"integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
 			"dependencies": {
-				"vscode-jsonrpc": "6.0.0",
-				"vscode-languageserver-types": "3.16.0"
+				"vscode-jsonrpc": "9.0.1",
+				"vscode-languageserver-types": "3.18.0"
 			}
 		},
+		"node_modules/vscode-languageserver-textdocument": {
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.13.tgz",
+			"integrity": "sha512-nx0ZHwMGIsVkzFG3/VLeJYBLTaFBRuNdGDvevvjuoayU5EOS2fEYazOhtCM3PI9ClMMg5igc0uwXtAq4tJj+Dw=="
+		},
 		"node_modules/vscode-languageserver-types": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-			"integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+			"integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g=="
 		}
 	},
 	"dependencies": {
 		"@types/vscode": {
-			"version": "1.77.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.77.0.tgz",
-			"integrity": "sha512-MWFN5R7a33n8eJZJmdVlifjig3LWUNRrPeO1xemIcZ0ae0TEQuRc7G2xV0LUX78RZFECY1plYBn+dP/Acc3L0Q==",
+			"version": "1.91.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.91.0.tgz",
+			"integrity": "sha512-PgPr+bUODjG3y+ozWUCyzttqR9EHny9sPAfJagddQjDwdtf66y2sDKJMnFZRuzBA2YtBGASqJGPil8VDUPvO6A==",
 			"dev": true
 		},
 		"@vscode/test-electron": {
@@ -591,17 +597,16 @@
 			"dev": true
 		},
 		"balanced-match": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="
 		},
 		"brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
 			"requires": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
+				"balanced-match": "^4.0.2"
 			}
 		},
 		"chalk": {
@@ -624,11 +629,6 @@
 			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
 			"integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
 			"dev": true
-		},
-		"concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"core-util-is": {
 			"version": "1.0.3",
@@ -753,11 +753,11 @@
 			"dev": true
 		},
 		"minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
 			"requires": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "^5.0.8"
 			}
 		},
 		"ms": {
@@ -836,9 +836,9 @@
 			"dev": true
 		},
 		"semver": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="
 		},
 		"setimmediate": {
 			"version": "1.0.5",
@@ -894,33 +894,39 @@
 			"dev": true
 		},
 		"vscode-jsonrpc": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-			"integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
+			"integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw=="
 		},
 		"vscode-languageclient": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
-			"integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-10.1.0.tgz",
+			"integrity": "sha512-XXRx6lqVitQy/oOLr9MfNYRG+MbQkhXkDaxbQMiKxEm8zZNfheRFUKNb8UYNh2stn9btl2wQM5wZFJjJvoc+jA==",
 			"requires": {
-				"minimatch": "^3.0.4",
-				"semver": "^7.3.4",
-				"vscode-languageserver-protocol": "3.16.0"
+				"minimatch": "^10.2.5",
+				"semver": "^7.8.1",
+				"vscode-languageserver-protocol": "3.18.2",
+				"vscode-languageserver-textdocument": "1.0.13"
 			}
 		},
 		"vscode-languageserver-protocol": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-			"integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+			"version": "3.18.2",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
+			"integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
 			"requires": {
-				"vscode-jsonrpc": "6.0.0",
-				"vscode-languageserver-types": "3.16.0"
+				"vscode-jsonrpc": "9.0.1",
+				"vscode-languageserver-types": "3.18.0"
 			}
 		},
+		"vscode-languageserver-textdocument": {
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.13.tgz",
+			"integrity": "sha512-nx0ZHwMGIsVkzFG3/VLeJYBLTaFBRuNdGDvevvjuoayU5EOS2fEYazOhtCM3PI9ClMMg5igc0uwXtAq4tJj+Dw=="
+		},
 		"vscode-languageserver-types": {
-			"version": "3.16.0",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-			"integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+			"integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g=="
 		}
 	}
 }

--- a/DevSkim-VSCode-Plugin/client/package.json
+++ b/DevSkim-VSCode-Plugin/client/package.json
@@ -11,13 +11,13 @@
 		"url": "https://github.com/Microsoft/devskim.git"
 	},
 	"engines": {
-		"vscode": "^1.63.0"
+		"vscode": "^1.91.0"
 	},
 	"dependencies": {
-		"vscode-languageclient": "^7.0.0"
+		"vscode-languageclient": "^10.1.0"
 	},
 	"devDependencies": {
-		"@types/vscode": "^1.63.0",
+		"@types/vscode": "^1.91.0",
 		"@vscode/test-electron": "^2.5.2"
 	}
 }

--- a/DevSkim-VSCode-Plugin/client/tsconfig.json
+++ b/DevSkim-VSCode-Plugin/client/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
-		"module": "commonjs",
+		"module": "node16",
+		"moduleResolution": "node16",
 		"target": "es2019",
 		"lib": [
 			"ES2019"

--- a/DevSkim-VSCode-Plugin/package-lock.json
+++ b/DevSkim-VSCode-Plugin/package-lock.json
@@ -17,11 +17,11 @@
 				"esbuild": "^0.28.1",
 				"eslint": "^9.0.0",
 				"nerdbank-gitversioning": "^3.4.255",
-				"typescript": "^4.5.5",
+				"typescript": "^5.9.3",
 				"typescript-eslint": "^8.54.0"
 			},
 			"engines": {
-				"vscode": "^1.63.0"
+				"vscode": "^1.91.0"
 			}
 		},
 		"node_modules/@azu/format-text": {
@@ -1500,16 +1500,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "18 || 20 || >=22"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -1801,16 +1801,16 @@
 			}
 		},
 		"node_modules/@vscode/vsce/node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "18 || 20 || >=22"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/@vscode/vsce/node_modules/glob": {
@@ -2051,9 +2051,9 @@
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2993,9 +2993,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
 			"dev": true,
 			"funding": [
 				{
@@ -3776,9 +3776,9 @@
 			}
 		},
 		"node_modules/linkify-it": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-			"integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+			"integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -5512,9 +5512,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.9.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -5563,9 +5563,9 @@
 			"license": "MIT"
 		},
 		"node_modules/undici": {
-			"version": "7.24.6",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
-			"integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+			"integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/DevSkim-VSCode-Plugin/package.json
+++ b/DevSkim-VSCode-Plugin/package.json
@@ -23,7 +23,7 @@
 		"theme": "dark"
 	},
 	"engines": {
-		"vscode": "^1.63.0"
+		"vscode": "^1.91.0"
 	},
 	"bugs": {
 		"url": "https://github.com/Microsoft/DevSkim/issues"
@@ -328,7 +328,7 @@
 		"esbuild": "^0.28.1",
 		"eslint": "^9.0.0",
 		"nerdbank-gitversioning": "^3.4.255",
-		"typescript": "^4.5.5",
+		"typescript": "^5.9.3",
 		"typescript-eslint": "^8.54.0"
 	}
 }

--- a/DevSkim-VSCode-Plugin/tsconfig.json
+++ b/DevSkim-VSCode-Plugin/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compilerOptions": {
-		"module": "commonjs",
+		"module": "node16",
+		"moduleResolution": "node16",
 		"target": "es2019",
 		"lib": [
 			"ES2019"


### PR DESCRIPTION
Folds the five open Dependabot pull requests for the VS Code extension into a single change, so the new `.github/dependabot.yml` grouping (#770) starts from a clean slate.

Supersedes #765, #766, #767, #768 and #769 — GitHub's closing keywords only auto-close issues, not pull requests, so those five need closing by hand (or Dependabot will retire them itself on its next run once these versions are on `main`).

## Straightforward bumps

Cherry-picked as-is from the Dependabot branches:

| PR | Bump |
|----|------|
| #765 | `linkify-it` 5.0.1 → 5.0.2 |
| #766 | `fast-uri` 3.1.2 → 3.1.4 |
| #768 | `undici` 7.24.6 → 7.29.0 |
| #769 | `brace-expansion` 1.1.14 → 1.1.16 and 5.0.5 → 5.0.8 |

## 🚩 Three of Dependabot's pins point at versions that no longer exist

`brace-expansion` **1.1.18** and **5.0.9** (#769, #767) and `minimatch` **10.2.6** (pulled in by #767) have been **removed from the npm registry**. The packument no longer records them even in its `time` field, and the tarballs 404 on every mirror — including the pipeline's own `PublicRegistriesFeed`:

```
npm error 404 Not Found - GET .../PublicRegistriesFeed/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz
  Cannot find the file brace-expansion-1.1.18.tgz in package 'brace-expansion 1.1.18' in feed 'PublicRegistriesFeed'
```

The first push of this branch reproduced exactly that failure in `DevSkim-VSCode-PR`, which is also what #767 and #769 would have hit had the Azure DevOps pipelines run on Dependabot's branches. They're pinned here to the newest releases that do exist — **1.1.16**, **5.0.8** and **10.2.5** (current `latest` for both packages).

Worth knowing independently of this PR: Dependabot can pin versions that later vanish, and nothing in the current setup notices until a build breaks.

## The other one that wasn't straightforward: #767

#767 also bundled a **major `vscode-languageclient` 7 → 10** bump, which does not build on its own. It's carried here with the migration it needs:

- **`node16` module resolution.** `vscode-languageclient` 10 dropped `main`/`types` and declares its entry points only through `exports`, which node10 resolution can't see — `tsc` fails with `Cannot find module 'vscode-languageclient/node'`. Both `tsconfig.json` files move to `module`/`moduleResolution: node16`. The client has no `"type": "module"`, so it still emits CommonJS, matching the `esbuild --format=cjs` bundle step.
- **`typescript` `^4.5.5` → `^5.9.3`.** The v10 type declarations use the `NoInfer` utility type (TypeScript 5.4+); with 4.9.5 you get ~40 `TS2304: Cannot find name 'NoInfer'` errors out of `node_modules`.
- **`client/extension.ts` lifecycle migration.** `LanguageClient.start()` returns `Promise<void>` instead of a `Disposable`, and `onReady()` was removed in v8. Notification handlers now register *before* `start()` — v10 queues them in `_pendingNotificationHandlers` and wires them when the connection opens, so nothing sent during initialization can be missed — and the client itself goes into `context.subscriptions`.
- **`engines.vscode` `^1.63.0` → `^1.91.0`** (root and client), which `vscode-languageclient` 10 requires. `@types/vscode` is pinned to the matching **1.91.0** rather than floating to latest, so the extension isn't type-checked against APIs newer than the version it claims to support.

### ⚠️ This drops support for VS Code 1.63 – 1.90

That's the unavoidable cost of `vscode-languageclient` 10 and the main thing worth a second opinion on. Ping me if you'd rather split the migration out and land only the mechanical bumps.

## Verification

- `npm ci` in both `DevSkim-VSCode-Plugin/` and `DevSkim-VSCode-Plugin/client/` — every integrity hash verifies
- `npm run compile` (`tsc -b`) — clean
- `npm run lint` (`eslint ./client`) — clean
- `npm run esbuild-base` — bundles at 959.4 kb

Not verified here: the extension end-to-end against the language server. The .NET server uses `OmniSharp.Extensions.LanguageServer` 0.19.9 (LSP 3.16/3.17) and the client now speaks protocol 3.18. That's backwards compatible by design — capabilities are negotiated — but **a manual smoke test in the Extension Development Host is worth doing before merge**, since there's no automated integration coverage.

<details>
<summary>Note on lockfile provenance</summary>

`registry.npmjs.org` isn't reachable from my environment, only an Azure Artifacts mirror. So rather than regenerating lockfiles (which would have rewritten `resolved` URLs to the mirror and downgraded `sha512` integrity to the mirror's `sha1` shasums), I kept Dependabot's entries and hand-edited only the lines that changed — `typescript`, `@types/vscode`, and the three repinned packages above.

Their `sha512` values were computed from the actual tarballs. The method was cross-checked against `undici` 7.29.0 and `brace-expansion` 5.0.8, whose hashes reproduce Dependabot's exactly, and the whole tree then verified with a real `npm ci` in both directories.

</details>

## Changelog

Entry added under `[1.0.96]`, from `nbgv get-version -v SimpleVersion` on this branch rebased on `main` (`main` is 1.0.95). If other PRs merge ahead of this one the git height shifts, so the heading needs a re-check before merging.
