### PR TITLE
Docs: mention MegaLinter in the README

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.96] - 2026-08-08
+### Documentation
+- Mentioned in the README that DevSkim is also available through [MegaLinter](https://megalinter.io/), which embeds it as one of its CI linters.
+
 ## [1.0.95] - 2026-07-31
 ### Pipeline
 - Added `.github/dependabot.yml` so Dependabot consolidates npm, NuGet, and GitHub Actions version updates into a single weekly pull request via a multi-ecosystem group, groups security updates per ecosystem into one pull request each, and labels its pull requests `no changelog` so the changelog gate passes.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ DevSkim is also available as a [GitHub Action](https://github.com/microsoft/DevS
 
 Platform specific binaries of the DevSkim CLI are also available on our GitHub [releases page](https://github.com/microsoft/DevSkim/releases).
 
+DevSkim is also embedded in [MegaLinter](https://megalinter.io/), an open-source aggregator of linters for CI, which runs DevSkim out of the box on analyzed repositories (see the [DevSkim descriptor](https://megalinter.io/latest/descriptors/repository_devskim/)).
+
 ## Installation
 
 ### Visual Studio Extension


### PR DESCRIPTION
Hi! I maintain [MegaLinter](https://megalinter.io/), an open-source linters aggregator for CI, which has been embedding the DevSkim CLI for a while now ([descriptor page](https://megalinter.io/latest/descriptors/repository_devskim/)).

This PR just adds a short line about it in the README's Official Releases section, next to the GitHub Action mention, so users looking for ways to run DevSkim in CI can find it.

Also added the required Changelog.md entry (version heading taken from `nbgv get-version` on the branch, currently 1.0.96 — happy to adjust if it drifts before merge).

Thanks for DevSkim!